### PR TITLE
Fix LOA role check and add regression test

### DIFF
--- a/NightCityBot/cogs/loa.py
+++ b/NightCityBot/cogs/loa.py
@@ -33,7 +33,8 @@ class LOA(commands.Cog):
             await ctx.send("❌ Permission denied.")
             return
 
-        if loa_role in target.roles:
+        # Compare by ID to avoid issues with mocked Role equality
+        if any(r.id == loa_role.id for r in target.roles):
             await ctx.send(f"{target.display_name} is already on LOA.")
             return
 
@@ -61,7 +62,8 @@ class LOA(commands.Cog):
             await ctx.send("❌ Permission denied.")
             return
 
-        if loa_role not in target.roles:
+        # Compare by ID to avoid issues with mocked Role equality
+        if not any(r.id == loa_role.id for r in target.roles):
             await ctx.send(f"{target.display_name} is not currently on LOA.")
             return
 

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -35,6 +35,7 @@ TEST_MODULES = {
     "test_start_rp_multi": "Starts RP with two users and ends it.",
     "test_cyberware_weekly": "Simulates the weekly cyberware task.",
     "test_loa_fixer_other": "Fixer starts and ends LOA for another user.",
+    "test_loa_id_check": "Handles LOA with distinct role instances sharing an ID.",
     "test_roll_as_user": "Rolls on behalf of another user.",
 }
 

--- a/NightCityBot/tests/test_loa_id_check.py
+++ b/NightCityBot/tests/test_loa_id_check.py
@@ -1,0 +1,31 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure LOA works when different Role objects share the same ID."""
+    logs: List[str] = []
+    loa = suite.bot.get_cog('LOA')
+    if not loa:
+        logs.append("❌ LOA cog not loaded")
+        return logs
+    fixer = MagicMock()
+    fixer.name = config.FIXER_ROLE_NAME
+    ctx.author.roles.append(fixer)
+    target = MagicMock(spec=discord.Member)
+    target.roles = []
+    target.add_roles = AsyncMock()
+    target.remove_roles = AsyncMock()
+    loa_role1 = MagicMock(spec=discord.Role)
+    loa_role1.id = config.LOA_ROLE_ID
+    loa_role2 = MagicMock(spec=discord.Role)
+    loa_role2.id = config.LOA_ROLE_ID
+    with patch.object(ctx.guild, 'get_role', side_effect=[loa_role1, loa_role2]):
+        await loa.start_loa.callback(loa, ctx, target)
+        target.roles.append(loa_role1)
+        await loa.end_loa.callback(loa, ctx, target)
+    suite.assert_send(logs, target.add_roles, "add_roles")
+    suite.assert_send(logs, target.remove_roles, "remove_roles")
+    ctx.author.roles.remove(fixer)
+    return logs


### PR DESCRIPTION
## Summary
- compare LOA roles by ID instead of object equality
- cover scenario with multiple role instances in new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc4afe5c0832f9169044770a3f151