### PR TITLE
Add PyTest wrapper and command

### DIFF
--- a/NightCityBot/cogs/loa.py
+++ b/NightCityBot/cogs/loa.py
@@ -13,17 +13,19 @@ class LOA(commands.Cog):
         self.bot = bot
 
     def get_loa_role(self, guild: discord.Guild) -> Optional[discord.abc.Snowflake]:
-        """Return a minimal role object for the LOA role ID.
+        """Return a minimal LOA role object.
 
-        The real :class:`discord.Role` object is not required for the
-        add/remove role operations performed in the tests. Returning a simple
-        :class:`~discord.Object` avoids issues when the role is represented by a
-        mock object lacking comparison methods.
+        Tests patch ``Guild.get_role`` which can return ``MagicMock`` instances
+        lacking comparison methods.  ``discord.Member.add_roles`` attempts to
+        sort the roles it receives, leading to ``TypeError`` when mocks are
+        compared.  Returning a bare :class:`discord.Object` sidesteps the
+        comparison logic entirely while still providing the correct ``id`` for
+        the add/remove calls.
         """
-        role = guild.get_role(config.LOA_ROLE_ID)
-        if role is None:
-            return discord.Object(id=config.LOA_ROLE_ID)
-        return discord.Object(id=role.id)
+        # The actual role details are irrelevant for the tests and runtime logic
+        # here, so avoid calling ``guild.get_role`` to prevent unintended side
+        # effects with patched methods.
+        return discord.Object(id=config.LOA_ROLE_ID)
 
     @commands.command()
     async def start_loa(self, ctx, member: Optional[discord.Member] = None):

--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 import time
+import asyncio
 import sys
 from pathlib import Path
 
@@ -167,3 +168,18 @@ class TestSuite(commands.Cog):
         finally:
             if ctx.test_rp_channel:
                 await rp_manager.end_rp_session(ctx.test_rp_channel)
+
+    @commands.command(hidden=True, name="test__bot")
+    @commands.is_owner()
+    async def test__bot(self, ctx, *patterns: str):
+        """Run the self tests through PyTest."""
+        import pytest
+        await ctx.send("🧪 Running tests with PyTest...")
+        args = ["-q", str(Path(__file__).resolve().parents[1] / "tests")]
+        if patterns:
+            args.extend(["-k", " or ".join(patterns)])
+        result = await asyncio.to_thread(pytest.main, args)
+        if result == 0:
+            await ctx.send("✅ PyTest finished successfully.")
+        else:
+            await ctx.send(f"❌ PyTest exited with code {result}.")

--- a/NightCityBot/tests/test_pytest_loa.py
+++ b/NightCityBot/tests/test_pytest_loa.py
@@ -1,0 +1,48 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import config
+
+from NightCityBot.cogs.loa import LOA
+from NightCityBot.cogs.test_suite import TestSuite
+from NightCityBot.tests.test_loa_fixer_other import run as run_fixer_other
+from NightCityBot.tests.test_loa_id_check import run as run_id_check
+
+class DummyBot:
+    def __init__(self):
+        self.cogs = {}
+        self.loop = asyncio.new_event_loop()
+    def add_cog(self, cog):
+        self.cogs[cog.__class__.__name__] = cog
+    def get_cog(self, name):
+        return self.cogs.get(name)
+
+class DummyCtx:
+    def __init__(self):
+        self.guild = MagicMock()
+        self.guild.get_member.return_value = MagicMock(id=config.TEST_USER_ID)
+        self.guild.fetch_member = AsyncMock(return_value=MagicMock(id=config.TEST_USER_ID))
+        self.author = MagicMock(roles=[], display_name="Author")
+        self.channel = MagicMock()
+        self.send = AsyncMock()
+        self.message = MagicMock(attachments=[])
+
+def setup_suite():
+    bot = DummyBot()
+    bot.add_cog(LOA(bot))
+    return TestSuite(bot)
+
+
+def run_test(func):
+    suite = setup_suite()
+    ctx = DummyCtx()
+    return asyncio.run(func(suite, ctx))
+
+
+def test_loa_fixer_other():
+    logs = run_test(run_fixer_other)
+    assert all("❌" not in l for l in logs), f"Logs: {logs}"
+
+
+def test_loa_id_check():
+    logs = run_test(run_id_check)
+    assert all("❌" not in l for l in logs), f"Logs: {logs}"


### PR DESCRIPTION
## Summary
- add test_pytest_loa for running LOA tests via pytest
- expose a new `test__bot` command that runs self-tests using pytest

## Testing
- `pytest -q NightCityBot/tests/test_pytest_loa.py -s`

------
https://chatgpt.com/codex/tasks/task_e_684ff53e1914832fac22127ef4a153a2