### PR TITLE
Add verbose test debugging

### DIFF
--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -20,6 +20,12 @@ class TestSuite(commands.Cog):
         self.bot = bot
         self.tests = tests.TEST_FUNCTIONS
         self.test_descriptions = tests.TEST_DESCRIPTIONS
+        self.verbose = False
+
+    def debug(self, logs: List[str], message: str) -> None:
+        """Append a debug message when verbose output is enabled."""
+        if self.verbose:
+            logs.append(f"🔍 {message}")
 
     async def get_test_user(self, ctx) -> Optional[discord.Member]:
         """Get or fetch the test user."""
@@ -61,6 +67,9 @@ class TestSuite(commands.Cog):
         if "-verbose" in test_names:
             test_names.remove("-verbose")
             verbose = True
+
+        self.verbose = verbose
+        ctx.verbose = verbose
 
         output_channel = ctx.channel
         if silent:

--- a/NightCityBot/tests/test_start_end_rp.py
+++ b/NightCityBot/tests/test_start_end_rp.py
@@ -9,9 +9,11 @@ async def run(suite, ctx) -> List[str]:
     logs = []
     rp_manager = suite.bot.get_cog('RPManager')
     channel = await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
+    suite.debug(logs, f"start_rp created: {getattr(channel, 'name', None)}")
     if channel:
         logs.append("✅ start_rp returned a channel")
         await rp_manager.end_rp(ctx)
+        suite.debug(logs, "end_rp called")
         logs.append("✅ end_rp executed without error")
     else:
         logs.append("❌ start_rp failed to create a channel")

--- a/NightCityBot/tests/test_start_rp_multi.py
+++ b/NightCityBot/tests/test_start_rp_multi.py
@@ -13,11 +13,13 @@ async def run(suite, ctx) -> List[str]:
     channel.name = "text-rp-test"
     rp.create_group_rp_channel = AsyncMock(return_value=channel)
     result = await rp.start_rp(ctx, f"<@{user.id}>", str(ctx.author.id))
+    suite.debug(logs, f"start_rp_multi created: {getattr(result, 'name', None)}")
     if result:
         logs.append("✅ start_rp handled users")
     await suite.bot.get_cog('RollSystem').loggable_roll(ctx.author, channel, "1d6")
     rp.end_rp_session = AsyncMock()
     ctx.channel = channel
     await rp.end_rp(ctx)
+    suite.debug(logs, "end_rp called in multi")
     suite.assert_called(logs, rp.end_rp_session, "end_rp_session")
     return logs

--- a/config.py
+++ b/config.py
@@ -18,6 +18,7 @@ OPEN_LOG_FILE = "business_open_log.json"
 LAST_RENT_FILE = "last_rent.json"
 ATTEND_LOG_FILE = "attendance_log.json"
 CYBERWARE_LOG_FILE = "cyberware_log.json"
+SYSTEM_STATUS_FILE = "system_status.json"
 CYBER_CHECKUP_ROLE_ID = 0
 CYBER_MEDIUM_ROLE_ID = 0
 CYBER_HIGH_ROLE_ID = 0


### PR DESCRIPTION
## Summary
- support debug messages when running tests with `-verbose`
- log channel creation in RP-related tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_685091adbb34832fad3c38bfa037ddb2