### PR TITLE
Fix thread cleanup and delete command messages

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -56,6 +56,10 @@ class Admin(commands.Cog):
                 await self.log_audit(ctx.author, f"✅ Posted anonymously to {dest_channel.mention}.")
         else:
             await ctx.send("❌ Provide a message or attachment.")
+        try:
+            await ctx.message.delete()
+        except Exception:
+            pass
 
     @commands.command(name="help")
     async def block_help(self, ctx):

--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -187,6 +187,10 @@ class DMHandler(commands.Cog):
         control = self.bot.get_cog('SystemControl')
         if control and not control.is_enabled('dm'):
             await ctx.send("⚠️ The dm system is currently disabled.")
+            try:
+                await ctx.message.delete()
+            except Exception:
+                pass
             return
         try:
             if not user:
@@ -196,12 +200,20 @@ class DMHandler(commands.Cog):
             admin = self.bot.get_cog('Admin')
             if admin:
                 await admin.log_audit(ctx.author, "❌ Failed DM: Could not resolve user.")
+            try:
+                await ctx.message.delete()
+            except Exception:
+                pass
             return
         except Exception as e:
             await ctx.send(f"⚠️ Unexpected error: {str(e)}")
             admin = self.bot.get_cog('Admin')
             if admin:
                 await admin.log_audit(ctx.author, f"⚠️ Exception in DM: {str(e)}")
+            try:
+                await ctx.message.delete()
+            except Exception:
+                pass
             return
 
         file_links = [attachment.url for attachment in ctx.message.attachments]
@@ -218,7 +230,11 @@ class DMHandler(commands.Cog):
                 setattr(fake_ctx, "original_author", ctx.author)
                 await roll_cog.roll(fake_ctx, dice=dice)
                 await ctx.send(f"✅ Rolled `{dice}` anonymously for {user.display_name}.")
-                return
+            try:
+                await ctx.message.delete()
+            except Exception:
+                pass
+            return
 
         # Handle normal DM
         dm_content_parts = [message] if message else []
@@ -247,3 +263,8 @@ class DMHandler(commands.Cog):
             admin = self.bot.get_cog('Admin')
             if admin:
                 await admin.log_audit(ctx.author, f"❌ Failed DM: Recipient: {user} (Privacy settings).")
+        finally:
+            try:
+                await ctx.message.delete()
+            except Exception:
+                pass

--- a/NightCityBot/cogs/rp_manager.py
+++ b/NightCityBot/cogs/rp_manager.py
@@ -109,8 +109,10 @@ class RPManager(commands.Cog):
             reason="Creating private RP group channel"
         )
 
-    async def end_rp_session(self, channel: discord.TextChannel):
-        """Archives and ends an RP session."""
+    async def end_rp_session(
+            self, channel: discord.TextChannel
+    ) -> Optional[discord.Thread]:
+        """Archive and end an RP session and return the created log thread."""
         logger.debug("end_rp_session started for channel %s", channel)
         log_channel = channel.guild.get_channel(config.GROUP_AUDIT_LOG_CHANNEL_ID)
         logger.debug("audit channel resolved as %s", log_channel)
@@ -125,7 +127,7 @@ class RPManager(commands.Cog):
                     channel,
                 )
                 await channel.delete(reason="RP session ended without log channel")
-                return
+                return None
 
             participants = channel.name.replace("text-rp-", "").split("-")
             thread_name = "GroupRP-" + "-".join(participants)
@@ -157,6 +159,8 @@ class RPManager(commands.Cog):
 
             logger.debug("deleting RP channel %s after logging", channel)
             await channel.delete(reason="RP session ended and logged.")
+            return log_thread
         except Exception as e:
             logger.exception("Failed to end RP session: %s", e)
             await channel.send(f"⚠️ Error ending RP: {e}")
+            return None

--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -180,12 +180,22 @@ class TestSuite(commands.Cog):
         finally:
             if ctx.test_rp_channel:
                 logger.debug("Cleaning up test RP channel %s", ctx.test_rp_channel)
-                await rp_manager.end_rp_session(ctx.test_rp_channel)
+                thread = await rp_manager.end_rp_session(ctx.test_rp_channel)
+                if thread:
+                    try:
+                        await thread.delete(reason="Test cleanup")
+                    except Exception:
+                        logger.exception("Failed to delete log thread %s", thread)
             for ch in ctx.guild.text_channels:
                 if ch.name.startswith("text-rp-") and ch != ctx.test_rp_channel:
                     try:
                         logger.debug("Cleaning residual RP channel %s", ch)
-                        await rp_manager.end_rp_session(ch)
+                        thread = await rp_manager.end_rp_session(ch)
+                        if thread:
+                            try:
+                                await thread.delete(reason="Test cleanup")
+                            except Exception:
+                                logger.exception("Failed to delete log thread %s", thread)
                     except Exception:
                         logger.exception("Failed to clean RP channel %s", ch)
 

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -38,6 +38,7 @@ TEST_MODULES = {
     "test_loa_fixer_other": "Fixer starts and ends LOA for another user.",
     "test_loa_id_check": "Handles LOA with distinct role instances sharing an ID.",
     "test_roll_as_user": "Rolls on behalf of another user.",
+    "test_message_cleanup": "Ensures !dm and !post delete their commands.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_message_cleanup.py
+++ b/NightCityBot/tests/test_message_cleanup.py
@@ -1,0 +1,35 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure !dm and !post delete the invoking message."""
+    logs: List[str] = []
+    dm_cog = suite.bot.get_cog('DMHandler')
+    admin_cog = suite.bot.get_cog('Admin')
+    user = await suite.get_test_user(ctx)
+
+    ctx.message.delete = AsyncMock()
+    ctx.message.attachments = []
+    with patch.object(type(user), "send", new=AsyncMock()), \
+         patch.object(dm_cog, "get_or_create_dm_thread", new=AsyncMock(return_value=MagicMock(spec=discord.Thread))):
+        await dm_cog.dm.callback(dm_cog, ctx, user, message="Hello")
+    if ctx.message.delete.await_count:
+        logs.append("✅ !dm deleted command message")
+    else:
+        logs.append("❌ !dm did not delete command")
+
+    ctx.message.delete.reset_mock()
+    dest = MagicMock(spec=discord.TextChannel)
+    dest.name = "general"
+    dest.send = AsyncMock()
+    parent = MagicMock()
+    parent.threads = []
+    with patch.object(type(ctx.guild), "text_channels", new=PropertyMock(return_value=[dest, parent])):
+        with patch.object(suite.bot, "invoke", new=AsyncMock()):
+            await admin_cog.post(ctx, dest.name, message="Test")
+    if ctx.message.delete.await_count:
+        logs.append("✅ !post deleted command message")
+    else:
+        logs.append("❌ !post did not delete command")
+    return logs


### PR DESCRIPTION
## Summary
- clean up RP log threads after running test suite
- delete invoking messages for `!dm` and `!post`
- return created log thread from `end_rp_session`
- test new message deletion behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850df5936e4832f9818a0ae95085b0f