### PR TITLE
Fix unknown command after due output

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -50,6 +50,8 @@ class NightCityBot(commands.Bot):
         await self.add_cog(TestSuite(self))
 
     async def on_message(self, message: discord.Message):
+        if message.author == self.user or message.author.bot:
+            return
         dm_handler = self.get_cog('DMHandler')
         if dm_handler and isinstance(message.channel, discord.Thread):
             if message.channel.id in getattr(dm_handler, 'dm_threads', {}).values():


### PR DESCRIPTION
## Summary
- avoid processing messages from bots including our own when handling on_message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685122cad140832fa2286fad375c9ff9