### PR TITLE
Add debug logging for unknown commands and due command

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -206,6 +206,7 @@ class Admin(commands.Cog):
             if cmd in constants.UNBELIEVABOAT_COMMANDS:
                 return
             # Otherwise show a basic notice but do not audit
+            print(f"[DEBUG] Unknown command from {ctx.author}: {ctx.message.content}")
             await ctx.send("❌ Unknown command.")
             return
         elif isinstance(error, commands.CheckFailure):

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -218,6 +218,7 @@ class Economy(commands.Cog):
     @commands.command(name="due")
     async def due(self, ctx):
         """Show estimated amount you will owe on the 1st of the month."""
+        print(f"[DEBUG] due command invoked by {ctx.author} in {ctx.channel}")
         total, details = self.calculate_due(ctx.author)
         lines = [f"💸 **Estimated Due:** ${total}"] + [f"• {d}" for d in details]
         await ctx.send("\n".join(lines))


### PR DESCRIPTION
## Summary
- print debug information for unknown commands in `Admin.on_command_error`
- log invocation details for the `due` command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685133d888d8832fa38612ae705cd6fb