### PR TITLE
Add more context to debug logs

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -206,6 +206,11 @@ class Admin(commands.Cog):
             if cmd in constants.UNBELIEVABOAT_COMMANDS:
                 return
             # Otherwise show a basic notice but do not audit
+            print(
+                f"[DEBUG] Unknown command from {ctx.author}"
+                f" in {getattr(ctx.channel, 'name', ctx.channel.id)}"
+                f" ({ctx.channel.id}) → {ctx.message.content!r}"
+            )
             await ctx.send("❌ Unknown command.")
             return
         elif isinstance(error, commands.CheckFailure):

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -218,6 +218,10 @@ class Economy(commands.Cog):
     @commands.command(name="due")
     async def due(self, ctx):
         """Show estimated amount you will owe on the 1st of the month."""
+        print(
+            f"[DEBUG] due command invoked by {ctx.author} ({ctx.author.id})"
+            f" in {getattr(ctx.channel, 'name', ctx.channel.id)} ({ctx.channel.id})"
+        )
         total, details = self.calculate_due(ctx.author)
         lines = [f"💸 **Estimated Due:** ${total}"] + [f"• {d}" for d in details]
         await ctx.send("\n".join(lines))


### PR DESCRIPTION
## Summary
- log channel name and ID when unknown commands occur
- include author and channel details in `due` debug message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685133d888d8832fa38612ae705cd6fb