### PR TITLE
Add verbose flag to rent commands

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -161,11 +161,11 @@ class Admin(commands.Cog):
         embed.add_field(
             name="💵 Rent Commands",
             value=(
-                "`!collect_rent [@user]` — Run monthly rent collection globally or for one user.\n"
+                "`!collect_rent [@user]` — Run monthly rent collection globally or for one user. Use `-v` for verbose output.\n"
                 "`!collect_housing @user` — Charge housing rent immediately.\n"
                 "`!collect_business @user` — Charge business rent immediately.\n"
                 "`!collect_trauma @user` — Process Trauma Team subscription.\n"
-                "`!simulate_rent` — Preview rent collection without changes.\n"
+                "`!simulate_rent` — Preview rent collection without changes. Use `-v` for verbose output.\n"
                 "`!simulate_cyberware` — Preview weekly cyberware costs."
             ),
             inline=False,


### PR DESCRIPTION
## Summary
- allow `collect_rent` and `simulate_rent` to accept `-v`/`--verbose`
- display minimal status messages unless verbose
- document the new flag in Admin help

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851e70d3a04832f90cd1ece7cc85fef