### PR TITLE
Fix DM self-tests to invoke real send

### DIFF
--- a/NightCityBot/tests/test_dm_plain.py
+++ b/NightCityBot/tests/test_dm_plain.py
@@ -9,11 +9,10 @@ async def run(suite, ctx) -> List[str]:
     logs: List[str] = []
     dm = suite.bot.get_cog('DMHandler')
     user = await suite.get_test_user(ctx)
-    send_mock = AsyncMock()
-    with patch.object(type(user), "send", new=send_mock):
-        ctx.send = AsyncMock()
-        ctx.message.attachments = []
+    ctx.send = AsyncMock()
+    ctx.message.attachments = []
+    with patch.object(type(user), "send", wraps=user.send) as send_mock:
         with patch.object(dm, "get_or_create_dm_thread", new=AsyncMock(return_value=MagicMock(spec=discord.Thread))):
             await dm.dm.callback(dm, ctx, user, message="Hello there!")
-    suite.assert_send(logs, send_mock, "user.send")
+        suite.assert_send(logs, send_mock, "user.send")
     return logs

--- a/NightCityBot/tests/test_dm_userid.py
+++ b/NightCityBot/tests/test_dm_userid.py
@@ -12,10 +12,10 @@ async def run(suite, ctx) -> List[str]:
     dummy = MagicMock(spec=discord.User)
     dummy.id = user.id
     dummy.display_name = user.display_name
-    dummy.send = AsyncMock()
     ctx.send = AsyncMock()
     ctx.message.attachments = []
-    with patch.object(dm, "get_or_create_dm_thread", new=AsyncMock(return_value=MagicMock(spec=discord.Thread))):
-        await dm.dm.callback(dm, ctx, dummy, message="Test")
-    suite.assert_send(logs, dummy.send, "user.send")
+    with patch.object(type(dummy), "send", wraps=dummy.send) as send_mock:
+        with patch.object(dm, "get_or_create_dm_thread", new=AsyncMock(return_value=MagicMock(spec=discord.Thread))):
+            await dm.dm.callback(dm, ctx, dummy, message="Test")
+        suite.assert_send(logs, send_mock, "user.send")
     return logs


### PR DESCRIPTION
## Summary
- adjust DM tests to call the actual send method while tracking calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520a467958832faa7cbef6cf76bc38