### PR TITLE
Fix DM userid test and refine RP cleanup

### DIFF
--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -117,6 +117,9 @@ class TestSuite(commands.Cog):
 
         rp_manager = self.bot.get_cog('RPManager')
         rp_channel = None
+        ctx.initial_rp_channels = {
+            ch.id for ch in ctx.guild.text_channels if ch.name.startswith("text-rp-")
+        }
         needs_rp = (not test_names) or any(name in rp_required_tests for name, _ in tests)
         if needs_rp:
             rp_channel = await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
@@ -187,7 +190,11 @@ class TestSuite(commands.Cog):
                     except Exception:
                         logger.exception("Failed to delete log thread %s", thread)
             for ch in ctx.guild.text_channels:
-                if ch.name.startswith("text-rp-") and ch != ctx.test_rp_channel:
+                if (
+                    ch.name.startswith("text-rp-")
+                    and ch != ctx.test_rp_channel
+                    and ch.id not in getattr(ctx, "initial_rp_channels", set())
+                ):
                     try:
                         logger.debug("Cleaning residual RP channel %s", ch)
                         thread = await rp_manager.end_rp_session(ch)

--- a/NightCityBot/tests/test_dm_userid.py
+++ b/NightCityBot/tests/test_dm_userid.py
@@ -14,7 +14,7 @@ async def run(suite, ctx) -> List[str]:
     dummy.display_name = user.display_name
     ctx.send = AsyncMock()
     ctx.message.attachments = []
-    with patch.object(type(dummy), "send", wraps=dummy.send) as send_mock:
+    with patch.object(dummy, "send", wraps=dummy.send) as send_mock:
         with patch.object(dm, "get_or_create_dm_thread", new=AsyncMock(return_value=MagicMock(spec=discord.Thread))):
             await dm.dm.callback(dm, ctx, dummy, message="Test")
         suite.assert_send(logs, send_mock, "user.send")


### PR DESCRIPTION
## Summary
- fix DM handler userid test's MagicMock patch
- track initial RP channels and skip pre-existing channels in cleanup

## Testing
- `python -m py_compile NightCityBot/cogs/test_suite.py NightCityBot/tests/test_dm_userid.py`

------
https://chatgpt.com/codex/tasks/task_e_68520da23988832fbc2558cb0f01e242