### PR TITLE
Add unbelievaboat connectivity test and stricter failures

### DIFF
--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -140,7 +140,10 @@ class TestSuite(commands.Cog):
 
                 all_logs.append(f"{name} — {self.test_descriptions.get(name, '')}")
                 all_logs.extend(logs)
-                if any("❌" in l for l in logs):
+                fail_logs = any("❌" in l for l in logs) or any(
+                    "Could not fetch balance" in l for l in logs
+                )
+                if fail_logs:
                     failed_tests += 1
                 else:
                     passed_tests += 1

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -41,6 +41,7 @@ TEST_MODULES = {
     "test_message_cleanup": "Ensures !dm and !post delete their commands.",
     "test_balance_backup": "Ensures collect_rent backs up balances before processing.",
     "test_test_bot_dm": "Runs test_bot in silent mode and checks DM output.",
+    "test_unbelievaboat_connection": "Verifies connection to the UnbelievaBoat API.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_unbelievaboat_connection.py
+++ b/NightCityBot/tests/test_unbelievaboat_connection.py
@@ -1,0 +1,20 @@
+from typing import List
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Verify connection to the UnbelievaBoat API."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    if not economy:
+        logs.append("❌ Economy cog not loaded")
+        return logs
+    try:
+        ok = await economy.unbelievaboat.verify_balance_ops(config.TEST_USER_ID)
+        if ok:
+            logs.append("✅ Verified UnbelievaBoat connectivity")
+        else:
+            logs.append("❌ Could not verify UnbelievaBoat connectivity")
+    except Exception as e:
+        logs.append(f"❌ Exception: {e}")
+    return logs
+


### PR DESCRIPTION
## Summary
- fail tests when balance fetch fails
- add a test for UnbelievaBoat API connectivity

## Testing
- `python -m py_compile NightCityBot/tests/test_unbelievaboat_connection.py`
- `python -m py_compile NightCityBot/cogs/test_suite.py`
- `pytest -q NightCityBot/tests/test_pytest_loa.py` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_685264b9b67c832f9078803ed8d8172f