### PR TITLE
Delay startup checks until guild cache ready

### DIFF
--- a/NightCityBot/utils/startup_checks.py
+++ b/NightCityBot/utils/startup_checks.py
@@ -85,5 +85,6 @@ async def cleanup_logs(bot: discord.Client) -> None:
             print(f"✅ Cleaned orphaned entries from {path.name}")
 
 async def perform_startup_checks(bot: discord.Client) -> None:
+    await bot.wait_until_ready()
     await verify_config(bot)
     await cleanup_logs(bot)


### PR DESCRIPTION
## Summary
- ensure startup checks run after the bot is ready so guild lookup succeeds

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685268c827d4832faa3659bed9736617