### PR TITLE
Fix self-test patching issues

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -17,6 +17,10 @@ from NightCityBot.utils.constants import (
     TRAUMA_ROLE_COSTS,
 )
 from NightCityBot.utils import helpers
+
+# Expose helper functions for tests that patch them directly
+load_json_file = helpers.load_json_file
+save_json_file = helpers.save_json_file
 import config
 from NightCityBot.services.unbelievaboat import UnbelievaBoatAPI
 from NightCityBot.services.trauma_team import TraumaTeamService

--- a/NightCityBot/tests/test_test_bot_dm.py
+++ b/NightCityBot/tests/test_test_bot_dm.py
@@ -11,7 +11,8 @@ async def run(suite, ctx) -> List[str]:
     dm_channel.send = AsyncMock()
     ctx.send = AsyncMock()
     ctx.message.attachments = []
-    with patch.object(type(ctx.author), "create_dm", new=AsyncMock(return_value=dm_channel)):
+    # create=True allows patching even though MagicMock lacks the attribute
+    with patch.object(type(ctx.author), "create_dm", new=AsyncMock(return_value=dm_channel), create=True):
         # Limit to a simple test
         test_cog.tests = {'test_help_commands': tests.TEST_FUNCTIONS['test_help_commands']}
         await test_cog.test_bot(ctx, 'test_help_commands', '-silent')


### PR DESCRIPTION
## Summary
- expose `load_json_file` and `save_json_file` in `Economy` so tests can patch them
- allow patching `create_dm` in DM summary test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685296c5577c832f9a4aeb0155948cb4