### PR TITLE
Fix test patching for open_shop and attend

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -115,7 +115,7 @@ class Economy(commands.Cog):
         now_str = now.isoformat()
 
         async with self.open_log_lock:
-            data = await helpers.load_json_file(config.OPEN_LOG_FILE, default={})
+            data = await load_json_file(config.OPEN_LOG_FILE, default={})
 
             all_opens = data.get(user_id, [])
             this_month_opens = [
@@ -135,7 +135,7 @@ class Economy(commands.Cog):
 
             all_opens.append(now_str)
             data[user_id] = all_opens
-            await helpers.save_json_file(config.OPEN_LOG_FILE, data)
+            await save_json_file(config.OPEN_LOG_FILE, data)
 
         reward = 0
         role_names = [r.name for r in ctx.author.roles]
@@ -176,7 +176,7 @@ class Economy(commands.Cog):
         now_str = now.isoformat()
 
         async with self.attend_lock:
-            data = await helpers.load_json_file(config.ATTEND_LOG_FILE, default={})
+            data = await load_json_file(config.ATTEND_LOG_FILE, default={})
 
             all_logs = data.get(user_id, [])
             parsed = [datetime.fromisoformat(ts) for ts in all_logs]
@@ -186,7 +186,7 @@ class Economy(commands.Cog):
 
             all_logs.append(now_str)
             data[user_id] = all_logs
-            await helpers.save_json_file(config.ATTEND_LOG_FILE, data)
+            await save_json_file(config.ATTEND_LOG_FILE, data)
 
         reward = ATTEND_REWARD
         await self.unbelievaboat.update_balance(ctx.author.id, {"cash": reward}, reason="Attendance reward")
@@ -276,7 +276,7 @@ class Economy(commands.Cog):
                     "cash": bal.get("cash", 0),
                     "bank": bal.get("bank", 0),
                 }
-        await helpers.save_json_file(path, data)
+        await save_json_file(path, data)
 
     async def deduct_flat_fee(self, member: discord.Member, cash: int, bank: int, log: List[str], amount: int = BASELINE_LIVING_COST, *, dry_run: bool = False) -> tuple[bool, int, int]:
         total = (cash or 0) + (bank or 0)
@@ -584,7 +584,7 @@ class Economy(commands.Cog):
 
         if not target_user:
             if Path(config.OPEN_LOG_FILE).exists():
-                business_open_log = await helpers.load_json_file(config.OPEN_LOG_FILE, default={})
+                business_open_log = await load_json_file(config.OPEN_LOG_FILE, default={})
                 if not dry_run:
                     backup_base = f"open_history_{datetime.utcnow():%B_%Y}.json"
                     backup_path = Path(backup_base)
@@ -597,10 +597,10 @@ class Economy(commands.Cog):
                 business_open_log = {}
 
             if not dry_run:
-                await helpers.save_json_file(config.OPEN_LOG_FILE, {})
+                await save_json_file(config.OPEN_LOG_FILE, {})
         else:
             if Path(config.OPEN_LOG_FILE).exists():
-                business_open_log = await helpers.load_json_file(config.OPEN_LOG_FILE, default={})
+                business_open_log = await load_json_file(config.OPEN_LOG_FILE, default={})
             else:
                 business_open_log = {}
 


### PR DESCRIPTION
## Summary
- ensure economy uses the exposed helper aliases
- this lets tests patch load/save functions and run concurrently

## Testing
- `pytest tests/test_pytest_loa.py::test_loa_fixer_other -q`
- `pytest tests/test_pytest_loa.py::test_loa_id_check -q`
- `pytest -k "test_pytest_loa" -q`


------
https://chatgpt.com/codex/tasks/task_e_68529887f934832fbdb35fc3299e844d