### PR TITLE
Bug fixes for roleplay, DM logging, and channel restrictions

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -1,4 +1,6 @@
 import logging
+import io
+import contextlib
 
 import discord
 from discord.ext import commands
@@ -248,5 +250,9 @@ class Admin(commands.Cog):
     async def check_config(self, ctx):
         """Re-run startup configuration checks."""
         await ctx.send("🔍 Running configuration checks...")
-        await startup_checks.verify_config(self.bot)
-        await ctx.send("✅ Configuration check complete. See console for details.")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            await startup_checks.verify_config(self.bot)
+        output = buf.getvalue().strip() or "(no output)"
+        await ctx.send(f"```{output}```")
+        await ctx.send("✅ Configuration check complete.")

--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -257,6 +257,12 @@ class DMHandler(commands.Cog):
                     await thread.send(
                         f"✅ Rolled `{dice}` anonymously for {user.display_name}."
                     )
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(
+                        ctx.author,
+                        f"✅ Rolled `{dice}` anonymously for {user.display_name}.",
+                    )
             try:
                 await ctx.message.delete()
             except Exception:

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -45,13 +45,15 @@ class Economy(commands.Cog):
     async def on_message(self, message: discord.Message):
         if message.author == self.bot.user or message.author.bot:
             return
-        if message.channel.id == config.BUSINESS_ACTIVITY_CHANNEL_ID:
+        channel_id = message.channel.id
+        parent_id = getattr(message.channel, 'parent_id', None)
+        if channel_id == config.BUSINESS_ACTIVITY_CHANNEL_ID or parent_id == config.BUSINESS_ACTIVITY_CHANNEL_ID:
             if not message.content.strip().startswith(("!open_shop", "!openshop", "!os")):
                 try:
                     await message.delete()
                 except Exception:
                     pass
-        if message.channel.id == config.ATTENDANCE_CHANNEL_ID:
+        if channel_id == config.ATTENDANCE_CHANNEL_ID or parent_id == config.ATTENDANCE_CHANNEL_ID:
             if not message.content.strip().startswith("!attend"):
                 try:
                     await message.delete()
@@ -123,7 +125,9 @@ class Economy(commands.Cog):
             await ctx.send("⚠️ The open_shop system is currently disabled.")
             return
         if ctx.channel.id != config.BUSINESS_ACTIVITY_CHANNEL_ID:
-            await ctx.send("❌ You can only log business openings in the designated business activity channel.")
+            ch = ctx.guild.get_channel(config.BUSINESS_ACTIVITY_CHANNEL_ID)
+            mention = ch.mention if ch else "#open_shop"
+            await ctx.send(f"❌ Please use {mention} for this command.")
             return
 
         if not any(r.name.startswith("Business") for r in ctx.author.roles):
@@ -188,7 +192,9 @@ class Economy(commands.Cog):
             await ctx.send("⚠️ The attend system is currently disabled.")
             return
         if ctx.channel.id != config.ATTENDANCE_CHANNEL_ID:
-            await ctx.send("❌ You can only log attendance in the designated channel.")
+            ch = ctx.guild.get_channel(config.ATTENDANCE_CHANNEL_ID)
+            mention = ch.mention if ch else "#attend"
+            await ctx.send(f"❌ Please use {mention} for this command.")
             return
         if not any(r.id == config.VERIFIED_ROLE_ID for r in ctx.author.roles):
             await ctx.send("❌ You must be verified to use this command.")

--- a/NightCityBot/cogs/rp_manager.py
+++ b/NightCityBot/cogs/rp_manager.py
@@ -58,24 +58,14 @@ class RPManager(commands.Cog):
             await ctx.send("❌ Could not resolve any users.")
             return
 
-        usernames = [(u.name, u.id) for u in users]
-        thread_name = build_channel_name(usernames)
-        thread = await ctx.channel.create_thread(
-            name=thread_name,
-            type=discord.ChannelType.private_thread,
-            reason="Creating private RP thread",
-        )
-        for u in users:
-            await thread.add_user(u)
-        await thread.add_user(ctx.author)
-
+        channel = await self.create_group_rp_channel(guild, users)
         mentions = " ".join(user.mention for user in users)
         fixer_role = await ctx.guild.fetch_role(config.FIXER_ROLE_ID)
         fixer_mention = fixer_role.mention if fixer_role else ""
 
-        await thread.send(f"✅ RP session created! {mentions} {fixer_mention}")
-        await ctx.send(f"✅ RP thread created: {thread.mention}")
-        return thread
+        await channel.send(f"✅ RP session created! {mentions} {fixer_mention}")
+        await ctx.send(f"✅ RP channel created: {channel.mention}")
+        return channel
 
     @commands.command(
         aliases=["endrp", "rp_end", "rpend"]


### PR DESCRIPTION
## Summary
- revert `start_rp` to create a private channel instead of a thread
- log audit entries when rolling via the `!dm` command
- enforce message restrictions in business and attendance threads
- guide users to the proper channel when using `!open_shop` or `!attend`
- show check_config output directly in Discord

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853538c5a14832f92547610caaeaf2f