### PR TITLE
Add startup checks and improve logging

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -249,10 +249,9 @@ class Admin(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def check_config(self, ctx):
         """Re-run startup configuration checks."""
-        await ctx.send("🔍 Running configuration checks...")
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             await startup_checks.verify_config(self.bot)
         output = buf.getvalue().strip() or "(no output)"
-        await ctx.send(f"```{output}```")
-        await ctx.send("✅ Configuration check complete.")
+        await self.log_audit(ctx.author, f"`check_config` output:\n```{output}```")
+

--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -161,21 +161,24 @@ class DMHandler(commands.Cog):
                 return
 
             # Handle normal message relay
-            files = []
+            user_files = []
+            log_files = []
             for a in message.attachments:
                 if a.size > 8 * 1024 * 1024:
                     await message.channel.send(
                         f"⚠️ Attachment '{a.filename}' too large to forward."
                     )
                 else:
-                    files.append(await a.to_file())
+                    user_files.append(await a.to_file())
+                    log_files.append(await a.to_file())
             try:
-                await target_user.send(content=message.content or None, files=files)
+                await target_user.send(content=message.content or None, files=user_files)
             except discord.HTTPException:
                 await message.channel.send("⚠️ Failed to forward message — attachment too large.")
             await message.channel.send(
                 f"📤 **Sent to {target_user.display_name} ({target_user.id}) "
-                f"by {message.author.display_name} ({message.author.id}):**\n{message.content}"
+                f"by {message.author.display_name} ({message.author.id}):**\n{message.content}",
+                files=log_files
             )
             try:
                 await message.delete()
@@ -254,11 +257,6 @@ class DMHandler(commands.Cog):
                 setattr(fake_ctx, "original_author", ctx.author)
                 thread = await self.get_or_create_dm_thread(user)
                 await roll_cog.roll(fake_ctx, dice=dice)
-                if isinstance(thread, discord.abc.Messageable):
-                    await thread.send(
-                        f"✅ Rolled `{dice}` anonymously for {user.display_name}."
-                    )
-
                 admin = self.bot.get_cog('Admin')
                 if admin:
                     await admin.log_audit(

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -58,7 +58,7 @@ class Economy(commands.Cog):
                 if admin:
                     await admin.log_audit(
                         message.author,
-                        f"🗑️ Deleted message in {message.channel.mention}"
+                        f"🗑️ Deleted message in {message.channel.mention}: {message.content}"
                     )
         if channel_id == config.ATTENDANCE_CHANNEL_ID or parent_id == config.ATTENDANCE_CHANNEL_ID:
 
@@ -71,7 +71,7 @@ class Economy(commands.Cog):
                 if admin:
                     await admin.log_audit(
                         message.author,
-                        f"🗑️ Deleted message in {message.channel.mention}"
+                        f"🗑️ Deleted message in {message.channel.mention}: {message.content}"
                     )
 
     def cog_unload(self):

--- a/NightCityBot/cogs/rp_manager.py
+++ b/NightCityBot/cogs/rp_manager.py
@@ -55,12 +55,16 @@ class RPManager(commands.Cog):
                 users.append(member)
 
         if not users:
-            await ctx.send("❌ Could not resolve any users.")
+            admin = self.bot.get_cog('Admin')
+            if admin:
+                await admin.log_audit(ctx.author, "❌ start_rp failed: no users resolved")
             return
 
         channel = await self.create_group_rp_channel(ctx.guild, users + [ctx.author], ctx.channel.category)
         if not channel:
-            await ctx.send("❌ Failed to create RP channel.")
+            admin = self.bot.get_cog('Admin')
+            if admin:
+                await admin.log_audit(ctx.author, "❌ Failed to create RP channel.")
             return None
 
         mentions = " ".join(user.mention for user in users)
@@ -68,7 +72,9 @@ class RPManager(commands.Cog):
         fixer_mention = fixer_role.mention if fixer_role else ""
 
         await channel.send(f"✅ RP session created! {mentions} {fixer_mention}")
-        await ctx.send(f"✅ RP channel created: {channel.mention}")
+        admin = self.bot.get_cog('Admin')
+        if admin:
+            await admin.log_audit(ctx.author, f"✅ RP channel created: {channel.mention}")
         return channel
 
     @commands.command(

--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -64,12 +64,16 @@ class TestSuite(commands.Cog):
         test_names = list(test_names)
         silent = False
         verbose = False
+        dry_run = False
         if "-silent" in test_names:
             test_names.remove("-silent")
             silent = True
         if "-verbose" in test_names:
             test_names.remove("-verbose")
             verbose = True
+        if "-dry" in test_names:
+            test_names.remove("-dry")
+            dry_run = True
 
         self.verbose = verbose
         ctx.verbose = verbose
@@ -86,6 +90,12 @@ class TestSuite(commands.Cog):
             "test_post_executes_command",
             "test_post_roll_execution",
         }
+
+        if dry_run:
+            await output_channel.send(
+                f"🧪 Dry run — would execute: {', '.join(test_names) if test_names else 'all tests'}"
+            )
+            return
 
         if test_names:
             await output_channel.send(

--- a/NightCityBot/tests/test_attend_command.py
+++ b/NightCityBot/tests/test_attend_command.py
@@ -18,6 +18,20 @@ async def run(suite, ctx) -> List[str]:
     mock_author.roles = [discord.Object(id=config.VERIFIED_ROLE_ID)]
     ctx.author = mock_author
     ctx.send = AsyncMock()
+    original_channel = ctx.channel
+
+    # Wrong channel should be rejected
+    ctx.channel = MagicMock(id=9999)
+    sunday = datetime(2025, 6, 15)
+    with patch("NightCityBot.utils.helpers.get_tz_now", return_value=sunday):
+        await economy.attend(ctx)
+        msg = ctx.send.await_args[0][0]
+        if "Please use" in msg:
+            logs.append("✅ attend rejected in wrong channel")
+        else:
+            logs.append("❌ attend allowed in wrong channel")
+    ctx.send.reset_mock()
+    ctx.channel = original_channel
 
     # Non-Sunday should be rejected
     monday = datetime(2025, 6, 16)

--- a/NightCityBot/tests/test_start_end_rp.py
+++ b/NightCityBot/tests/test_start_end_rp.py
@@ -8,15 +8,15 @@ async def run(suite, ctx) -> List[str]:
     """Create and end an RP session to confirm logging works."""
     logs = []
     rp_manager = suite.bot.get_cog('RPManager')
-    thread = MagicMock(spec=discord.Thread)
-    ctx.channel.create_thread = AsyncMock(return_value=thread)
+    channel = MagicMock(spec=discord.TextChannel)
+    ctx.guild.create_text_channel = AsyncMock(return_value=channel)
     await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
-    if ctx.channel.create_thread.await_count:
-        logs.append("✅ start_rp created thread")
-        ctx.channel = thread
+    if ctx.guild.create_text_channel.await_count:
+        logs.append("✅ start_rp created channel")
+        ctx.channel = channel
         rp_manager.end_rp_session = AsyncMock()
         await rp_manager.end_rp(ctx)
         suite.assert_called(logs, rp_manager.end_rp_session, "end_rp_session")
     else:
-        logs.append("❌ start_rp failed to create thread")
+        logs.append("❌ start_rp failed to create channel")
     return logs

--- a/NightCityBot/tests/test_start_rp_multi.py
+++ b/NightCityBot/tests/test_start_rp_multi.py
@@ -9,17 +9,17 @@ async def run(suite, ctx) -> List[str]:
     logs: List[str] = []
     rp = suite.bot.get_cog('RPManager')
     user = await suite.get_test_user(ctx)
-    thread = MagicMock(spec=discord.Thread)
-    ctx.channel.create_thread = AsyncMock(return_value=thread)
+    channel = MagicMock(spec=discord.TextChannel)
+    ctx.guild.create_text_channel = AsyncMock(return_value=channel)
     await rp.start_rp(ctx, f"<@{user.id}>", str(ctx.author.id))
-    if ctx.channel.create_thread.await_count:
+    if ctx.guild.create_text_channel.await_count:
         logs.append("✅ start_rp handled users")
-        await suite.bot.get_cog('RollSystem').loggable_roll(ctx.author, thread, "1d6")
+        await suite.bot.get_cog('RollSystem').loggable_roll(ctx.author, channel, "1d6")
         rp.end_rp_session = AsyncMock()
-        ctx.channel = thread
+        ctx.channel = channel
         await rp.end_rp(ctx)
         suite.debug(logs, "end_rp called in multi")
         suite.assert_called(logs, rp.end_rp_session, "end_rp_session")
     else:
-        logs.append("❌ start_rp failed to create thread")
+        logs.append("❌ start_rp failed to create channel")
     return logs


### PR DESCRIPTION
## Summary
- verify UnbelievaBoat connectivity during startup and log when ready
- keep attachments when relaying fixer messages
- include deleted message text in audit log
- send check_config and start_rp results only to the audit log
- remove DM thread confirmation for roll relay
- allow dry-run flag for `!test_bot`
- update RP and attend tests for latest behaviour

## Testing
- `pytest NightCityBot/tests/test_pytest_loa.py -q`
- `pytest NightCityBot/tests/test_attend_command.py NightCityBot/tests/test_start_end_rp.py NightCityBot/tests/test_start_rp_multi.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68535eafd0ac832f8d455b2eaa46a9e2