### PR TITLE
Add startup confirmation and remove check_config

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -173,7 +173,6 @@ class Admin(commands.Cog):
             ),
             (
                 "🛠️ Admin Tools",
-                "`!check_config` – re-run startup checks to verify channel and role IDs.\n"
                 "`!test_bot [tests] [-silent] [-verbose]` – execute the built-in test suite. Results can be DMed when `-silent` is used and step details are shown with `-verbose`.\n"
                 "`!test__bot [pattern]` – run the PyTest suite optionally filtering by pattern.",
             ),
@@ -244,14 +243,4 @@ class Admin(commands.Cog):
                 config.AUDIT_LOG_CHANNEL_ID,
             )
         logger.info("AUDIT %s: %s", user, action_desc)
-
-    @commands.command(name="check_config", aliases=["config_check"])
-    @commands.has_permissions(administrator=True)
-    async def check_config(self, ctx):
-        """Re-run startup configuration checks."""
-        buf = io.StringIO()
-        with contextlib.redirect_stdout(buf):
-            await startup_checks.verify_config(self.bot)
-        output = buf.getvalue().strip() or "(no output)"
-        await self.log_audit(ctx.author, f"`check_config` output:\n```{output}```")
 

--- a/NightCityBot/tests/test_start_end_rp.py
+++ b/NightCityBot/tests/test_start_end_rp.py
@@ -9,14 +9,14 @@ async def run(suite, ctx) -> List[str]:
     logs = []
     rp_manager = suite.bot.get_cog('RPManager')
     channel = MagicMock(spec=discord.TextChannel)
-    ctx.guild.create_text_channel = AsyncMock(return_value=channel)
-    await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
-    if ctx.guild.create_text_channel.await_count:
-        logs.append("✅ start_rp created channel")
-        ctx.channel = channel
-        rp_manager.end_rp_session = AsyncMock()
-        await rp_manager.end_rp(ctx)
-        suite.assert_called(logs, rp_manager.end_rp_session, "end_rp_session")
-    else:
-        logs.append("❌ start_rp failed to create channel")
+    with patch.object(ctx.guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
+        await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
+        if mock_create.await_count:
+            logs.append("✅ start_rp created channel")
+            ctx.channel = channel
+            rp_manager.end_rp_session = AsyncMock()
+            await rp_manager.end_rp(ctx)
+            suite.assert_called(logs, rp_manager.end_rp_session, "end_rp_session")
+        else:
+            logs.append("❌ start_rp failed to create channel")
     return logs

--- a/NightCityBot/tests/test_start_rp_multi.py
+++ b/NightCityBot/tests/test_start_rp_multi.py
@@ -10,16 +10,16 @@ async def run(suite, ctx) -> List[str]:
     rp = suite.bot.get_cog('RPManager')
     user = await suite.get_test_user(ctx)
     channel = MagicMock(spec=discord.TextChannel)
-    ctx.guild.create_text_channel = AsyncMock(return_value=channel)
-    await rp.start_rp(ctx, f"<@{user.id}>", str(ctx.author.id))
-    if ctx.guild.create_text_channel.await_count:
-        logs.append("✅ start_rp handled users")
-        await suite.bot.get_cog('RollSystem').loggable_roll(ctx.author, channel, "1d6")
-        rp.end_rp_session = AsyncMock()
-        ctx.channel = channel
-        await rp.end_rp(ctx)
-        suite.debug(logs, "end_rp called in multi")
-        suite.assert_called(logs, rp.end_rp_session, "end_rp_session")
-    else:
-        logs.append("❌ start_rp failed to create channel")
+    with patch.object(ctx.guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
+        await rp.start_rp(ctx, f"<@{user.id}>", str(ctx.author.id))
+        if mock_create.await_count:
+            logs.append("✅ start_rp handled users")
+            await suite.bot.get_cog('RollSystem').loggable_roll(ctx.author, channel, "1d6")
+            rp.end_rp_session = AsyncMock()
+            ctx.channel = channel
+            await rp.end_rp(ctx)
+            suite.debug(logs, "end_rp called in multi")
+            suite.assert_called(logs, rp.end_rp_session, "end_rp_session")
+        else:
+            logs.append("❌ start_rp failed to create channel")
     return logs

--- a/NightCityBot/utils/startup_checks.py
+++ b/NightCityBot/utils/startup_checks.py
@@ -119,4 +119,5 @@ async def perform_startup_checks(bot: discord.Client) -> None:
     admin = bot.get_cog('Admin')
     if admin:
         await admin.log_audit(bot.user, "✅ Bot successfully started.")
+    print("✅ Bot successfully started and ready.")
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ GUILD_ID = 1234567890
 TIMEZONE = "America/New_York"  # or your preferred zone
 ```
 
-Run `!check_config` after changing any IDs to verify the setup.
+Configuration is verified automatically when the bot starts.
 
 ## Running the bot
 
@@ -130,7 +130,6 @@ Offers helper commands for staff and global error handling.
 
 * `!post <channel> <message>` – send a message or execute a command in another channel or thread. If `<message>` begins with `!`, the command is run as if it were typed in that location.
 * `!helpme` and `!helpfixer` – show the built in help embeds. The former lists player commands while the latter documents every fixer and admin command with available options.
-* `!check_config` – re-run startup checks to confirm that every configured role and channel still exists.
 * All sensitive actions are logged via `log_audit` to the channel defined by `AUDIT_LOG_CHANNEL_ID`.
 
 ### TestSuite


### PR DESCRIPTION
## Summary
- log a success message when startup checks finish
- drop the `check_config` admin command and remove docs
- update help text and README
- fix RP manager tests to patch Guild properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685364ec9914832f89e6b2c9c7b9a8eb