### PR TITLE
Implement alias updates and verbose options

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -73,6 +73,7 @@ class Admin(commands.Cog):
             await ctx.send("❌ Provide a message or attachment.")
         try:
             await ctx.message.delete()
+            await self.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
         except Exception:
             pass
 
@@ -156,19 +157,19 @@ class Admin(commands.Cog):
                 "`!attend` – log weekly attendance for a $250 payout.\n"
                 "`!due` – display a detailed breakdown of what a user owes on the 1st.\n"
                 "`!collect_rent [@user] [-v]` – run the monthly rent cycle. `@user` targets one member and `-v` posts detailed logs.\n"
-                "`!collect_housing @user` / `!collect_business @user` / `!collect_trauma @user` – charge specific housing, business or Trauma Team fees immediately.\n"
+                "`!collect_housing @user [-v]` / `!collect_business @user [-v]` / `!collect_trauma @user [-v]` – charge specific fees with optional verbose logs.\n"
                 "`!simulate_rent [@user] [-v]` – perform a dry run of rent collection using the same options.\n"
                 "`!simulate_cyberware [@user] [week]` – preview cyberware medication costs globally or for a certain week.",
             ),
             (
                 "🏖️ LOA & Cyberware",
                 "`!start_loa [@user]` / `!end_loa [@user]` – toggle LOA for yourself or the specified member.\n"
-                "`!checkup @user` – remove the checkup role once an in-character exam is completed.\n"
-                "`!weeks_without_checkup @user` – show how many weeks a member has kept the role without a checkup.",
+                "`!checkup @user` (aliases: !check-up, !check_up, !cu, !cup) – remove the checkup role once an in-character exam is completed.\n"
+                "`!weeks_without_checkup @user` (aliases: !wwocup, !wwc) – show how many weeks a member has kept the role without a checkup.",
             ),
             (
                 "⚙️ System Control",
-                "`!enable_system <name>` / `!disable_system <name>` – turn major subsystems on or off.\n"
+                "`!enable_system <name>` / `!disable_system <name>` (aliases: !es/!ds) – toggle major subsystems.\n"
                 "`!system_status` – display the current enable/disable flags.",
             ),
             (
@@ -222,8 +223,9 @@ class Admin(commands.Cog):
             await ctx.send("❌ Unknown command.")
             return
         elif isinstance(error, commands.CheckFailure):
-            await ctx.send("❌ Permission denied.")
-            await self.log_audit(ctx.author, f"❌ Permission denied: {ctx.message.content}")
+            reason = str(error) or "Permission denied."
+            await ctx.send(f"❌ {reason}")
+            await self.log_audit(ctx.author, f"❌ {reason}: {ctx.message.content}")
         else:
             await ctx.send(f"⚠️ Error: {str(error)}")
             await self.log_audit(ctx.author, f"⚠️ Error: {ctx.message.content} → {str(error)}")

--- a/NightCityBot/cogs/cyberware.py
+++ b/NightCityBot/cogs/cyberware.py
@@ -227,7 +227,7 @@ class CyberwareManager(commands.Cog):
         if admin_cog:
             await admin_cog.log_audit(ctx.author, summary)
 
-    @commands.command()
+    @commands.command(aliases=["check-up", "check_up", "cu", "cup"])
     @is_ripperdoc()
     async def checkup(self, ctx, member: discord.Member):
         """Remove the weekly cyberware checkup role from a member."""
@@ -260,7 +260,7 @@ class CyberwareManager(commands.Cog):
         self.data[str(member.id)] = 0
         await save_json_file(Path(config.CYBERWARE_LOG_FILE), self.data)
 
-    @commands.command(aliases=["weekswithoutcheckup"])
+    @commands.command(aliases=["weekswithoutcheckup", "wwocup", "wwc"])
     @commands.check_any(is_ripperdoc(), is_fixer())
     async def weeks_without_checkup(self, ctx, member: discord.Member):
         """Show how many weeks a member has gone without a checkup."""

--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -125,6 +125,9 @@ class DMHandler(commands.Cog):
                     await roll_cog.roll(ctx, dice=dice)
                 try:
                     await message.delete()
+                    admin = self.bot.get_cog('Admin')
+                    if admin:
+                        await admin.log_audit(message.author, f"🗑️ Deleted DM relay: {message.content}")
                 except Exception:
                     pass
                 return
@@ -142,6 +145,9 @@ class DMHandler(commands.Cog):
                     await rp_cog.start_rp(ctx, *args)
                 try:
                     await message.delete()
+                    admin = self.bot.get_cog('Admin')
+                    if admin:
+                        await admin.log_audit(message.author, f"🗑️ Deleted DM relay: {message.content}")
                 except Exception:
                     pass
                 return
@@ -156,6 +162,9 @@ class DMHandler(commands.Cog):
                 await self.bot.invoke(ctx)
                 try:
                     await message.delete()
+                    admin = self.bot.get_cog('Admin')
+                    if admin:
+                        await admin.log_audit(message.author, f"🗑️ Deleted DM relay: {message.content}")
                 except Exception:
                     pass
                 return
@@ -182,6 +191,9 @@ class DMHandler(commands.Cog):
             )
             try:
                 await message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(message.author, f"🗑️ Deleted DM relay: {message.content}")
             except Exception:
                 pass
 
@@ -216,6 +228,9 @@ class DMHandler(commands.Cog):
             await ctx.send("⚠️ The dm system is currently disabled.")
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
             except Exception:
                 pass
             return
@@ -229,6 +244,9 @@ class DMHandler(commands.Cog):
                 await admin.log_audit(ctx.author, "❌ Failed DM: Could not resolve user.")
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
             except Exception:
                 pass
             return
@@ -239,6 +257,9 @@ class DMHandler(commands.Cog):
                 await admin.log_audit(ctx.author, f"⚠️ Exception in DM: {str(e)}")
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
             except Exception:
                 pass
             return
@@ -266,6 +287,9 @@ class DMHandler(commands.Cog):
 
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
             except Exception:
                 pass
             return
@@ -300,5 +324,8 @@ class DMHandler(commands.Cog):
         finally:
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
             except Exception:
                 pass

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -487,8 +487,23 @@ class Economy(commands.Cog):
 
     @commands.command(aliases=["collecthousing"])
     @commands.has_permissions(administrator=True)
-    async def collect_housing(self, ctx, user: discord.Member):
+    async def collect_housing(self, ctx, *args):
         """Manually collect housing rent from a single user"""
+        converter = commands.MemberConverter()
+        user = None
+        verbose = False
+        for arg in args:
+            if arg.lower() in {"-v", "--verbose", "-verbose", "verbose"}:
+                verbose = True
+            elif user is None:
+                try:
+                    user = await converter.convert(ctx, arg)
+                except commands.BadArgument:
+                    continue
+        if user is None:
+            await ctx.send("❌ Could not resolve user.")
+            return
+
         control = self.bot.get_cog('SystemControl')
         if control and not control.is_enabled('housing_rent'):
             await ctx.send('⚠️ The housing_rent system is currently disabled.')
@@ -522,19 +537,44 @@ class Economy(commands.Cog):
             final_cash = final.get("cash", 0)
             final_bank = final.get("bank", 0)
             final_total = final_cash + final_bank
-            log.append(
-                f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
-            )
+        else:
+            final_cash = cash
+            final_bank = bank
+            final_total = final_cash + final_bank
+        log.append(
+            f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
+        )
 
         summary = "\n".join(log)
-        await ctx.send(f"✅ Completed for <@{user.id}>")
+        if verbose:
+            await ctx.send(summary)
+        else:
+            await ctx.send(
+                f"✅ Completed for <@{user.id}>\n"
+                f"Before: Cash ${cash:,}, Bank ${bank:,}\n"
+                f"After: Cash ${final_cash:,}, Bank ${final_bank:,}"
+            )
         if admin_cog:
             await admin_cog.log_audit(ctx.author, summary)
 
     @commands.command(aliases=["collectbusiness"])
     @commands.has_permissions(administrator=True)
-    async def collect_business(self, ctx, user: discord.Member):
+    async def collect_business(self, ctx, *args):
         """Manually collect business rent from a single user"""
+        converter = commands.MemberConverter()
+        user = None
+        verbose = False
+        for arg in args:
+            if arg.lower() in {"-v", "--verbose", "-verbose", "verbose"}:
+                verbose = True
+            elif user is None:
+                try:
+                    user = await converter.convert(ctx, arg)
+                except commands.BadArgument:
+                    continue
+        if user is None:
+            await ctx.send("❌ Could not resolve user.")
+            return
         control = self.bot.get_cog('SystemControl')
         if control and not control.is_enabled('business_rent'):
             await ctx.send('⚠️ The business_rent system is currently disabled.')
@@ -568,18 +608,43 @@ class Economy(commands.Cog):
             final_cash = final.get("cash", 0)
             final_bank = final.get("bank", 0)
             final_total = final_cash + final_bank
-            log.append(
-                f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
-            )
+        else:
+            final_cash = cash
+            final_bank = bank
+            final_total = final_cash + final_bank
+        log.append(
+            f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
+        )
 
         summary = "\n".join(log)
-        await ctx.send(f"✅ Completed for <@{user.id}>")
+        if verbose:
+            await ctx.send(summary)
+        else:
+            await ctx.send(
+                f"✅ Completed for <@{user.id}>\n"
+                f"Before: Cash ${cash:,}, Bank ${bank:,}\n"
+                f"After: Cash ${final_cash:,}, Bank ${final_bank:,}"
+            )
         if admin_cog:
             await admin_cog.log_audit(ctx.author, summary)
 
     @commands.command(aliases=["collecttrauma"])
     @commands.has_permissions(administrator=True)
-    async def collect_trauma(self, ctx, user: discord.Member):
+    async def collect_trauma(self, ctx, *args):
+        converter = commands.MemberConverter()
+        user = None
+        verbose = False
+        for arg in args:
+            if arg.lower() in {"-v", "--verbose", "-verbose", "verbose"}:
+                verbose = True
+            elif user is None:
+                try:
+                    user = await converter.convert(ctx, arg)
+                except commands.BadArgument:
+                    continue
+        if user is None:
+            await ctx.send("❌ Could not resolve user.")
+            return
         """Manually collect Trauma Team subscription"""
         control = self.bot.get_cog('SystemControl')
         if control and not control.is_enabled('trauma_team'):
@@ -608,12 +673,23 @@ class Economy(commands.Cog):
             final_cash = final.get("cash", 0)
             final_bank = final.get("bank", 0)
             final_total = final_cash + final_bank
-            log.append(
-                f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
-            )
+        else:
+            final_cash = cash
+            final_bank = bank
+            final_total = final_cash + final_bank
+        log.append(
+            f"📊 Final balance — Cash: ${final_cash:,}, Bank: ${final_bank:,}, Total: ${final_total:,}"
+        )
 
         summary = "\n".join(log)
-        await ctx.send(f"✅ Completed for <@{user.id}>")
+        if verbose:
+            await ctx.send(summary)
+        else:
+            await ctx.send(
+                f"✅ Completed for <@{user.id}>\n"
+                f"Before: Cash ${cash:,}, Bank ${bank:,}\n"
+                f"After: Cash ${final_cash:,}, Bank ${final_bank:,}"
+            )
         if admin_cog:
             await admin_cog.log_audit(ctx.author, summary)
 

--- a/NightCityBot/cogs/roll_system.py
+++ b/NightCityBot/cogs/roll_system.py
@@ -33,6 +33,9 @@ class RollSystem(commands.Cog):
         if original_sender:
             try:
                 await ctx.message.delete()
+                admin = self.bot.get_cog('Admin')
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted message: {ctx.message.content}")
             except Exception as e:
                 logger.warning("Couldn't delete relayed !roll command: %s", e)
             await self.loggable_roll(

--- a/NightCityBot/cogs/rp_manager.py
+++ b/NightCityBot/cogs/rp_manager.py
@@ -32,6 +32,8 @@ class RPManager(commands.Cog):
                 await self.bot.invoke(ctx)
                 try:
                     await message.delete()
+                    if admin:
+                        await admin.log_audit(message.author, f"🗑️ Deleted message in RP: {message.content}")
                 except Exception:
                     pass
                 return
@@ -55,16 +57,30 @@ class RPManager(commands.Cog):
                 users.append(member)
 
         if not users:
+            await ctx.send("❌ Could not resolve any users.")
             admin = self.bot.get_cog('Admin')
             if admin:
                 await admin.log_audit(ctx.author, "❌ start_rp failed: no users resolved")
+            try:
+                await ctx.message.delete()
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
+            except Exception:
+                pass
             return
 
         channel = await self.create_group_rp_channel(ctx.guild, users + [ctx.author], ctx.channel.category)
         if not channel:
+            await ctx.send("❌ Failed to create RP channel.")
             admin = self.bot.get_cog('Admin')
             if admin:
                 await admin.log_audit(ctx.author, "❌ Failed to create RP channel.")
+            try:
+                await ctx.message.delete()
+                if admin:
+                    await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
+            except Exception:
+                pass
             return None
 
         mentions = " ".join(user.mention for user in users)
@@ -75,6 +91,13 @@ class RPManager(commands.Cog):
         admin = self.bot.get_cog('Admin')
         if admin:
             await admin.log_audit(ctx.author, f"✅ RP channel created: {channel.mention}")
+        try:
+            await ctx.message.delete()
+            admin = self.bot.get_cog('Admin')
+            if admin:
+                await admin.log_audit(ctx.author, f"🗑️ Deleted command: {ctx.message.content}")
+        except Exception:
+            pass
         return channel
 
     @commands.command(

--- a/NightCityBot/cogs/system_control.py
+++ b/NightCityBot/cogs/system_control.py
@@ -44,7 +44,7 @@ class SystemControl(commands.Cog):
         await save_json_file(Path(config.SYSTEM_STATUS_FILE), self.status)
         return True
 
-    @commands.command(aliases=["enablesystem"])
+    @commands.command(aliases=["enablesystem", "es", "systemenable"])
     @commands.has_permissions(administrator=True)
     async def enable_system(self, ctx, system: str):
         """Enable a disabled system."""
@@ -59,7 +59,7 @@ class SystemControl(commands.Cog):
             return
         await ctx.send(f"✅ Enabled {system} system.")
 
-    @commands.command(aliases=["disablesystem"])
+    @commands.command(aliases=["disablesystem", "ds", "systemdisable"])
     @commands.has_permissions(administrator=True)
     async def disable_system(self, ctx, system: str):
         """Disable an active system."""

--- a/NightCityBot/tests/test_alias_registry.py
+++ b/NightCityBot/tests/test_alias_registry.py
@@ -19,9 +19,10 @@ import pytest
     (Economy, "collect_housing", ["collecthousing"]),
     (Economy, "collect_business", ["collectbusiness"]),
     (Economy, "collect_trauma", ["collecttrauma"]),
-    (CyberwareManager, "weeks_without_checkup", ["weekswithoutcheckup"]),
-    (SystemControl, "enable_system", ["enablesystem"]),
-    (SystemControl, "disable_system", ["disablesystem"]),
+    (CyberwareManager, "checkup", ["check-up", "check_up", "cu", "cup"]),
+    (CyberwareManager, "weeks_without_checkup", ["weekswithoutcheckup", "wwocup", "wwc"]),
+    (SystemControl, "enable_system", ["enablesystem", "es", "systemenable"]),
+    (SystemControl, "disable_system", ["disablesystem", "ds", "systemdisable"]),
     (SystemControl, "system_status", ["systemstatus"]),
     (TestSuite, "test_bot", ["testbot"]),
 ])

--- a/NightCityBot/utils/constants.py
+++ b/NightCityBot/utils/constants.py
@@ -30,7 +30,7 @@ ATTEND_REWARD = 250
 # Commands from UnbelievaBoat to ignore in unknown command handler
 UNBELIEVABOAT_COMMANDS = {
     "add-cash-role", "add-fail-reply", "add-failed-reply", "add-fine-reply",
-    "add-money", "add-money-role", "add-payout-reply", "add-reply", "agree",
+    "add-money", "addmoney", "add-money-role", "add-payout-reply", "add-reply", "agree",
     "agree-channel", "agree-role", "aki", "akinator", "amped-fm", "amped.fm", "animal",
     "animal-race", "animal-scale", "animals", "animals-scale", "ass",
     "assignable-role", "assignable-roles", "auto-mod-ignore", "auto-mod-ignored",
@@ -93,7 +93,7 @@ UNBELIEVABOAT_COMMANDS = {
     "random-user", "random-user-reaction", "reason", "reason-edit", "reason-set",
     "reddit", "remind", "remind-me", "reminder-delete", "reminder-forget",
     "reminder-list", "reminders", "remove-ban", "remove-case", "remove-cash-role",
-    "remove-item", "remove-money", "remove-money-role", "remove-punishment",
+    "remove-item", "remove-money", "removemoney", "remove-money-role", "remove-punishment",
     "remove-replies", "remove-reply", "remove-warning", "repeat", "repeat-queue",
     "reply-add", "request", "requests", "reset-balance", "reset-economy",
     "reset-money", "resume", "rm-ban", "rm-case", "rm-cash-role", "rm-item",

--- a/NightCityBot/utils/permissions.py
+++ b/NightCityBot/utils/permissions.py
@@ -7,21 +7,25 @@ def is_fixer():
     async def predicate(ctx):
         # in-guild messages
         if isinstance(ctx.author, discord.Member):
-            return discord.utils.get(ctx.author.roles, name=config.FIXER_ROLE_NAME) is not None
+            if discord.utils.get(ctx.author.roles, name=config.FIXER_ROLE_NAME) is not None:
+                return True
+            raise commands.CheckFailure("Fixer role required")
 
         # DMs or thread-posts: fetch member object from main guild
         guild = ctx.bot.get_guild(config.GUILD_ID)
         if not guild:
-            return False
+            raise commands.CheckFailure("Fixer role required")
 
         member = guild.get_member(ctx.author.id)
         if not member:
             try:
                 member = await guild.fetch_member(ctx.author.id)
             except discord.NotFound:
-                return False
+                raise commands.CheckFailure("Fixer role required")
 
-        return discord.utils.get(member.roles, name=config.FIXER_ROLE_NAME) is not None
+        if discord.utils.get(member.roles, name=config.FIXER_ROLE_NAME) is not None:
+            return True
+        raise commands.CheckFailure("Fixer role required")
 
     return commands.check(predicate)
 
@@ -31,7 +35,7 @@ def is_ripperdoc():
     async def predicate(ctx):
         guild = ctx.bot.get_guild(config.GUILD_ID)
         if not guild:
-            return False
+            raise commands.CheckFailure("Ripperdoc role required")
 
         member = ctx.author
         if not isinstance(member, discord.Member):
@@ -40,8 +44,10 @@ def is_ripperdoc():
                 try:
                     member = await guild.fetch_member(ctx.author.id)
                 except discord.NotFound:
-                    return False
+                    raise commands.CheckFailure("Ripperdoc role required")
 
-        return any(r.id == config.RIPPERDOC_ROLE_ID for r in getattr(member, "roles", []))
+        if any(r.id == config.RIPPERDOC_ROLE_ID for r in getattr(member, "roles", [])):
+            return True
+        raise commands.CheckFailure("Ripperdoc role required")
 
     return commands.check(predicate)


### PR DESCRIPTION
## Summary
- log deleted messages in audit channel
- add verbose flag handling to manual collection commands
- add new command aliases
- show permission failure reasons
- document the new options in help

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536c4bcd6c832f985b68b33f13c884