### PR TITLE
Fix failing tests

### DIFF
--- a/NightCityBot/tests/test_full_rent_commands.py
+++ b/NightCityBot/tests/test_full_rent_commands.py
@@ -25,13 +25,13 @@ async def run(suite, ctx) -> List[str]:
         await economy.collect_rent(ctx, target_user=user)
         logs.append("✅ collect_rent (specific user) executed")
 
-        await economy.collect_housing(ctx, user)
+        await economy.collect_housing(ctx, f"<@{user.id}>")
         logs.append("✅ collect_housing executed")
 
-        await economy.collect_business(ctx, user)
+        await economy.collect_business(ctx, f"<@{user.id}>")
         logs.append("✅ collect_business executed")
 
-        await economy.collect_trauma(ctx, user)
+        await economy.collect_trauma(ctx, f"<@{user.id}>")
         logs.append("✅ collect_trauma executed")
 
         logs.append("→ Result: ✅ All rent commands executed.")

--- a/NightCityBot/tests/test_start_end_rp.py
+++ b/NightCityBot/tests/test_start_end_rp.py
@@ -9,7 +9,7 @@ async def run(suite, ctx) -> List[str]:
     logs = []
     rp_manager = suite.bot.get_cog('RPManager')
     channel = MagicMock(spec=discord.TextChannel)
-    with patch.object(ctx.guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
+    with patch.object(discord.Guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
         await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
         if mock_create.await_count:
             logs.append("✅ start_rp created channel")

--- a/NightCityBot/tests/test_start_rp_multi.py
+++ b/NightCityBot/tests/test_start_rp_multi.py
@@ -10,7 +10,7 @@ async def run(suite, ctx) -> List[str]:
     rp = suite.bot.get_cog('RPManager')
     user = await suite.get_test_user(ctx)
     channel = MagicMock(spec=discord.TextChannel)
-    with patch.object(ctx.guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
+    with patch.object(discord.Guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
         await rp.start_rp(ctx, f"<@{user.id}>", str(ctx.author.id))
         if mock_create.await_count:
             logs.append("✅ start_rp handled users")

--- a/NightCityBot/tests/test_trauma_payment.py
+++ b/NightCityBot/tests/test_trauma_payment.py
@@ -12,7 +12,7 @@ async def run(suite, ctx) -> List[str]:
         logs.append("→ Expected: collect_trauma should find thread and log subscription payment.")
 
         economy = suite.bot.get_cog('Economy')
-        await economy.collect_trauma(ctx, user)
+        await economy.collect_trauma(ctx, f"<@{user.id}>")
         logs.append("→ Result: ✅ Trauma Team logic executed on live user (check #tt-plans-payment).")
     except Exception as e:
         logs.append(f"❌ Exception in test_trauma_payment: {e}")


### PR DESCRIPTION
## Summary
- update RP tests to patch `create_text_channel` on `discord.Guild`
- pass user mentions to manual rent commands in tests

## Testing
- `python -m py_compile NightCityBot/tests/test_full_rent_commands.py NightCityBot/tests/test_trauma_payment.py NightCityBot/tests/test_start_end_rp.py NightCityBot/tests/test_start_rp_multi.py`
- `pytest -q NightCityBot/tests/test_full_rent_commands.py::run 2>/tmp/pytest.log && cat /tmp/pytest.log | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68537716b47c832f9dab7e066e85ceb4