### PR TITLE
Fix failing tests with missing mocks

### DIFF
--- a/NightCityBot/tests/test_start_end_rp.py
+++ b/NightCityBot/tests/test_start_end_rp.py
@@ -9,6 +9,9 @@ async def run(suite, ctx) -> List[str]:
     logs = []
     rp_manager = suite.bot.get_cog('RPManager')
     channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    ctx.send = AsyncMock()
+    ctx.message.delete = AsyncMock()
     with patch.object(discord.Guild, "create_text_channel", AsyncMock(return_value=channel)) as mock_create:
         await rp_manager.start_rp(ctx, f"<@{config.TEST_USER_ID}>")
         if mock_create.await_count:

--- a/NightCityBot/tests/test_unknown_command.py
+++ b/NightCityBot/tests/test_unknown_command.py
@@ -9,6 +9,7 @@ async def run(suite, ctx) -> List[str]:
     """Send an unknown ! command and ensure it's ignored."""
     logs = []
     admin = suite.bot.get_cog('Admin')
+    ctx.send = AsyncMock()
     try:
         msg = ctx.message
         msg.content = "!notacommand"


### PR DESCRIPTION
## Summary
- patch RP start/end test to mock sending operations
- mock ctx.send in unknown command test

## Testing
- `pytest -q NightCityBot/tests/test_alias_registry.py`

------
https://chatgpt.com/codex/tasks/task_e_68537a2e8330832f8c238878a1c83f3e