### PR TITLE
Improve rent simulation and docs

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -159,7 +159,9 @@ class Admin(commands.Cog):
                 "`!collect_rent [@user] [-v]` (alias: !collectrent) – run the monthly rent cycle. `@user` targets one member and `-v` posts detailed logs.\n"
                 "`!collect_housing @user [-v]` / `!collect_business @user [-v]` / `!collect_trauma @user [-v]` – charge specific fees with optional verbose logs. (aliases: !collecthousing / !collectbusiness / !collecttrauma)\n"
                 "`!simulate_rent [@user] [-v]` (alias: !simulaterent) – perform a dry run of rent collection using the same options.\n"
-                "`!simulate_cyberware [@user] [week]` – preview cyberware medication costs globally or for a certain week.",
+                "`!simulate_cyberware [@user] [week]` – preview cyberware medication costs globally or for a certain week.\n"
+                "`!backup_balances` – save all member balances to a timestamped file.\n"
+                "`!restore_balances <file>` – restore balances from a backup file.",
             ),
             (
                 "🏖️ LOA & Cyberware",
@@ -174,7 +176,8 @@ class Admin(commands.Cog):
             ),
             (
                 "🛠️ Admin Tools",
-                "`!test_bot [tests] [-silent] [-verbose]` – execute the built-in test suite. Results can be DMed when `-silent` is used and step details are shown with `-verbose`.\n"
+                "`!test_bot [tests] [-silent] [-verbose]` – execute the built-in test suite. Results can be DMed when `-silent` is used and step details are shown with `-verbose`. Prefixes run groups of tests.\n"
+                "`!list_tests` – show all available self-test names.\n"
                 "`!test__bot [pattern]` – run the PyTest suite optionally filtering by pattern.",
             ),
         ]

--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -385,11 +385,12 @@ class Economy(commands.Cog):
 
         success = True
         if not dry_run:
-            success = await self.unbelievaboat.update_balance(member.id, payload, reason="Flat Monthly Fee")
+            success = await self.unbelievaboat.update_balance(
+                member.id, payload, reason="Flat Monthly Fee"
+            )
         if success:
-            if not dry_run:
-                cash -= deduct_cash
-                bank -= deduct_bank
+            cash -= deduct_cash
+            bank -= deduct_bank
             log.append(
                 f"{'💸 Would deduct' if dry_run else '💸 Deducted'} flat monthly fee of ${amount} (Cash: ${deduct_cash}, Bank: ${deduct_bank})."
             )
@@ -444,11 +445,12 @@ class Economy(commands.Cog):
 
         success = True
         if not dry_run:
-            success = await self.unbelievaboat.update_balance(member.id, payload, reason="Housing Rent")
+            success = await self.unbelievaboat.update_balance(
+                member.id, payload, reason="Housing Rent"
+            )
         if success:
-            if not dry_run:
-                cash -= deduct_cash
-                bank -= deduct_bank
+            cash -= deduct_cash
+            bank -= deduct_bank
             log.append(
                 f"🧮 {'Would subtract' if dry_run else 'Subtracted'} housing rent ${housing_total} — ${deduct_cash} from cash, ${deduct_bank} from bank."
             )
@@ -508,11 +510,12 @@ class Economy(commands.Cog):
 
         success = True
         if not dry_run:
-            success = await self.unbelievaboat.update_balance(member.id, payload, reason="Business Rent")
+            success = await self.unbelievaboat.update_balance(
+                member.id, payload, reason="Business Rent"
+            )
         if success:
-            if not dry_run:
-                cash -= deduct_cash
-                bank -= deduct_bank
+            cash -= deduct_cash
+            bank -= deduct_bank
             log.append(
                 f"🧮 {'Would subtract' if dry_run else 'Subtracted'} business rent ${business_total} — ${deduct_cash} from cash, ${deduct_bank} from bank."
             )
@@ -871,12 +874,15 @@ class Economy(commands.Cog):
                 if not on_loa:
                     await self.trauma_service.process_trauma_team_payment(member, log=log, dry_run=dry_run)
 
-                final = await self.unbelievaboat.get_balance(member.id)
-                if final:
-                    cash = final.get("cash", 0)
-                    bank = final.get("bank", 0)
+                if not dry_run:
+                    final = await self.unbelievaboat.get_balance(member.id)
+                    if final:
+                        cash = final.get("cash", 0)
+                        bank = final.get("bank", 0)
 
-                log.append(f"📊 Final balance — Cash: ${cash:,}, Bank: ${bank:,}, Total: {(cash or 0) + (bank or 0):,}")
+                log.append(
+                    f"📊 {'Projected' if dry_run else 'Final'} balance — Cash: ${cash:,}, Bank: ${bank:,}, Total: {(cash or 0) + (bank or 0):,}"
+                )
 
                 summary = "\n".join(log)
                 if verbose:

--- a/NightCityBot/tests/test_balance_backup.py
+++ b/NightCityBot/tests/test_balance_backup.py
@@ -9,7 +9,11 @@ async def run(suite, ctx) -> List[str]:
     economy = suite.bot.get_cog('Economy')
     ctx.send = AsyncMock()
     with (
-        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
+        patch.object(
+            economy.unbelievaboat,
+            "get_balance",
+            new=AsyncMock(return_value={"cash": 10000, "bank": 5000}),
+        ),
         patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
         patch.object(economy, "backup_balances", new=AsyncMock()) as mock_backup,
     ):

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Main commands:
 * `!collect_rent [@user] [-v]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Pass `-v` to print every deduction step in detail.
 * `!simulate_rent [@user] [-v]` – identical to `!collect_rent` but performs a dry run without updating balances.
 * `!collect_housing @user`, `!collect_business @user`, `!collect_trauma @user` – immediately charge a single user's housing rent, business rent or Trauma Team subscription.
+* `!backup_balances` – save all member balances to a timestamped JSON file.
+* `!restore_balances <file>` – restore balances from a previous backup file.
 
 The cog stores logs in JSON files such as `business_open_log.json` and `attendance_log.json` and consults `NightCityBot/utils/constants.py` for role costs.
 
@@ -137,7 +139,8 @@ Offers helper commands for staff and global error handling.
 
 Exposes the internal test suite directly through Discord commands.
 
-* `!test_bot [tests]` – execute the built-in test functions. Provide one or more test names to run them selectively. Use `-silent` to send results via DM and `-verbose` for step-by-step logs.
+* `!test_bot [tests]` – execute the built-in test functions. Provide one or more test names or prefixes to run them selectively. Use `-silent` to send results via DM and `-verbose` for step-by-step logs.
+* `!list_tests` – display the available self-test names.
 * `!test__bot [pattern]` – run the full PyTest suite. Optional patterns limit execution to matching tests. This command is primarily for repository maintainers.
 
 ## Services


### PR DESCRIPTION
## Summary
- simulate balance changes even in dry-run rent collection
- chunk `list_tests` output and support prefix patterns for `!test_bot`
- document new commands in README and help embed
- adjust balance backup test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d17122b8832fb305277bdb3de556