### PR TITLE
Add audit logging for test_bot

### DIFF
--- a/NightCityBot/cogs/test_suite.py
+++ b/NightCityBot/cogs/test_suite.py
@@ -68,6 +68,14 @@ class TestSuite(commands.Cog):
         except AssertionError:
             logs.append(f"❌ {label} was not called")
 
+    async def audit_log(self, ctx, message: str) -> None:
+        """Send a message to the audit log channel via the Admin cog."""
+        admin = self.bot.get_cog('Admin')
+        if not admin:
+            return
+        for i in range(0, len(message), 900):
+            await admin.log_audit(ctx.author, message[i : i + 900])
+
     @commands.command(hidden=True, aliases=["testbot"])
     @commands.is_owner()
     async def test_bot(self, ctx, *test_names: str):
@@ -93,6 +101,12 @@ class TestSuite(commands.Cog):
         self.verbose = verbose
         ctx.verbose = verbose
 
+        await self.audit_log(
+            ctx,
+            f"Started test_bot: {', '.join(test_names) if test_names else 'all tests'};"
+            f" silent={silent}, verbose={verbose}, dry_run={dry_run}"
+        )
+
         output_channel = ctx.channel
         if silent:
             output_channel = await ctx.author.create_dm()
@@ -109,6 +123,10 @@ class TestSuite(commands.Cog):
         if dry_run:
             await output_channel.send(
                 f"🧪 Dry run — would execute: {', '.join(test_names) if test_names else 'all tests'}"
+            )
+            await self.audit_log(
+                ctx,
+                f"Dry run — would execute: {', '.join(test_names) if test_names else 'all tests'}"
             )
             return
 
@@ -148,10 +166,15 @@ class TestSuite(commands.Cog):
             await output_channel.send(
                 f"🧪 Running selected tests on <@{config.TEST_USER_ID}>: {', '.join(expanded_names)}"
             )
+            await self.audit_log(
+                ctx,
+                f"Running selected tests: {', '.join(expanded_names)}"
+            )
         else:
             await output_channel.send(
                 f"🧪 Running full self-test on user <@{config.TEST_USER_ID}>..."
             )
+            await self.audit_log(ctx, "Running full self-test")
 
         rp_manager = self.bot.get_cog('RPManager')
         rp_channel = None
@@ -169,14 +192,20 @@ class TestSuite(commands.Cog):
                     await output_channel.send(
                         f"🧪 `{name}` — {self.test_descriptions.get(name, 'No description.')}"
                     )
+                await self.audit_log(
+                    ctx,
+                    f"Running test {name}: {self.test_descriptions.get(name, 'No description.')}"
+                )
                 try:
                     logs = await func(self, ctx)
                 except Exception as e:
                     logs = [f"❌ Exception in `{name}`: {e}"]
+                await self.audit_log(ctx, f"Results for {name}:\n" + "\n".join(str(l) for l in logs))
                 all_logs.append(f"{name} — {self.test_descriptions.get(name, '')}")
                 all_logs.extend(logs)
                 all_logs.append("────────────")
 
+            summary_text = "\n".join(str(l) for l in all_logs).strip()
             if verbose:
                 # Send results in chunks
                 current_chunk = ""
@@ -190,7 +219,6 @@ class TestSuite(commands.Cog):
                 if current_chunk:
                     await output_channel.send(f"```\n{current_chunk.strip()}\n```")
             else:
-                summary_text = "\n".join(str(l) for l in all_logs).strip()
                 current_chunk = ""
                 for line in summary_text.split("\n"):
                     if len(current_chunk) + len(line) + 1 > 1900:
@@ -200,6 +228,7 @@ class TestSuite(commands.Cog):
                         current_chunk += line + "\n"
                 if current_chunk:
                     await output_channel.send(f"```\n{current_chunk.strip()}\n```")
+            await self.audit_log(ctx, summary_text)
 
             # Summary embed
             passed = sum(1 for r in all_logs if "✅" in r)
@@ -218,6 +247,10 @@ class TestSuite(commands.Cog):
             )
             embed.set_footer(text=f"⏱️ Completed in {duration:.2f}s")
             await output_channel.send(embed=embed)
+            await self.audit_log(
+                ctx,
+                f"Summary: Passed {passed}, Failed {failed}, Duration {duration:.2f}s"
+            )
         finally:
             if ctx.test_rp_channel:
                 logger.debug("Cleaning up test RP channel %s", ctx.test_rp_channel)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Offers helper commands for staff and global error handling.
 
 Exposes the internal test suite directly through Discord commands.
 
-* `!test_bot [tests]` – execute the built-in test functions. Provide one or more test names or prefixes to run them selectively. Use `-silent` to send results via DM and `-verbose` for step-by-step logs.
+* `!test_bot [tests]` – execute the built-in test functions. Provide one or more test names or prefixes to run them selectively. Use `-silent` to send results via DM and `-verbose` for step-by-step logs. All output is also mirrored to the audit log channel for debugging.
 * `!list_tests` – display the available self-test names.
 * `!test__bot [pattern]` – run the full PyTest suite. Optional patterns limit execution to matching tests. This command is primarily for repository maintainers.
 


### PR DESCRIPTION
## Summary
- log detailed `test_bot` execution steps via `audit_log`
- mirror test output to the audit channel
- document that `!test_bot` now logs to the audit channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853de4cb07c832fb5f06211f51139da