### PR TITLE
Use real balances in rent simulation tests

### DIFF
--- a/NightCityBot/tests/test_full_rent_commands.py
+++ b/NightCityBot/tests/test_full_rent_commands.py
@@ -18,9 +18,7 @@ async def run(suite, ctx) -> List[str]:
         economy = suite.bot.get_cog('Economy')
         cyber = suite.bot.get_cog('CyberwareManager')
         with (
-            patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
-            patch.object(cyber.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(cyber.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
             patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),
         ):

--- a/NightCityBot/tests/test_rent_logging_sends.py
+++ b/NightCityBot/tests/test_rent_logging_sends.py
@@ -20,7 +20,6 @@ async def run(suite, ctx) -> List[str]:
 
         economy = suite.bot.get_cog('Economy')
         with (
-            patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
         ):
             await economy.simulate_rent(ctx, target_user=user)

--- a/NightCityBot/tests/test_simulate_commands.py
+++ b/NightCityBot/tests/test_simulate_commands.py
@@ -10,9 +10,7 @@ async def run(suite, ctx) -> List[str]:
     admin = suite.bot.get_cog('Admin')
     ctx.send = AsyncMock()
     with (
-        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
         patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
-        patch.object(cyber.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
         patch.object(cyber.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
         patch.object(admin, "log_audit", new=AsyncMock()) as mock_audit,
         patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),


### PR DESCRIPTION
## Summary
- remove balance mocks from rent simulation tests
- keep update_balance mocked to avoid real patches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e71943a0832f810876e32c1bbb71