### PR TITLE
Track balance changes in backups

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -326,11 +326,21 @@ class Economy(commands.Cog):
             if not bal:
                 continue
             file_path = backup_dir / f"{m.id}_{m.display_name}.json"
+
+            prev_entries = await load_json_file(file_path, default=[])
+            if isinstance(prev_entries, list) and prev_entries:
+                last = prev_entries[-1]
+                prev_total = (last.get("cash", 0) + last.get("bank", 0))
+                change = (bal.get("cash", 0) + bal.get("bank", 0)) - prev_total
+            else:
+                change = 0
+
             entry = {
                 "timestamp": datetime.utcnow().isoformat(),
                 "label": label,
                 "cash": bal.get("cash", 0),
                 "bank": bal.get("bank", 0),
+                "change": change,
             }
             await append_json_file(file_path, entry)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Main commands:
 * `!collect_rent [@user] [-v]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Pass `-v` to print every deduction step in detail.
 * `!simulate_rent [@user] [-v]` – identical to `!collect_rent` but performs a dry run without updating balances.
 * `!collect_housing @user`, `!collect_business @user`, `!collect_trauma @user` – immediately charge a single user's housing rent, business rent or Trauma Team subscription.
-* `!backup_balances` – save all member balances to a timestamped JSON file.
+* `!backup_balances` – save all member balances to a timestamped JSON file. Each
+  backup entry records the balance and the `change` since the previous entry.
 * `!restore_balances <file>` – restore balances from a previous backup file.
 
 The cog stores logs in JSON files such as `business_open_log.json` and `attendance_log.json` and consults `NightCityBot/utils/constants.py` for role costs.


### PR DESCRIPTION
## Summary
- add change delta to economy balance backups
- document the new `change` field in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685400d70500832f87c8ad0011178581