### PR TITLE
Support .env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Create a `config.py` file with your role and channel IDs. The bot uses an IANA
 timezone string via `TIMEZONE` to schedule weekly tasks such as `!open_shop`.
 Credentials like the Discord bot token and UnbelievaBoat API token can be
 provided through the environment variables `TOKEN` and
-`UNBELIEVABOAT_API_TOKEN`. Example `config.py`:
+`UNBELIEVABOAT_API_TOKEN`.  If a `.env` file exists in the project root its
+contents will be loaded automatically. Example `config.py`:
 
 ```python
 import os

--- a/config.py
+++ b/config.py
@@ -5,6 +5,12 @@ from environment variables if available so they don't need to be hard coded.
 """
 
 import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Automatically load variables from a `.env` file located next to this
+# config module so local development doesn't require exporting them.
+load_dotenv(Path(__file__).with_name('.env'))
 
 # Secrets can be provided via environment variables.  They default to ``None``
 # so running the bot locally can still work if these values are assigned below

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 aiofiles
 tzdata
 discord
+python-dotenv


### PR DESCRIPTION
## Summary
- auto-load a `.env` file from project root
- document `.env` support in the README
- add `python-dotenv` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549049329c832f97b938b52b1a29b1