### PR TITLE
Fix balance backup command

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -386,8 +386,21 @@ class Economy(commands.Cog):
         members = ctx.guild.members
         backup_dir = Path(config.BALANCE_BACKUP_DIR)
         backup_dir.mkdir(exist_ok=True)
-        file_path = backup_dir / f"manual_{datetime.utcnow():%Y%m%d_%H%M%S}.json"
-        await self.backup_balances(members, file_path)
+        filename = f"manual_{datetime.utcnow():%Y%m%d_%H%M%S}.json"
+        file_path = backup_dir / filename
+
+        data = {}
+        for m in members:
+            bal = await self.unbelievaboat.get_balance(m.id)
+            if not bal:
+                continue
+            data[str(m.id)] = {
+                "cash": bal.get("cash", 0),
+                "bank": bal.get("bank", 0),
+            }
+
+        await save_json_file(file_path, data)
+        await self.backup_balances(members, label=filename)
         await ctx.send(f"✅ Balances backed up to `{file_path.name}`")
 
     @commands.command(name="restore_balances")

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -40,6 +40,7 @@ TEST_MODULES = {
     "test_roll_as_user": "Rolls on behalf of another user.",
     "test_message_cleanup": "Ensures !dm and !post delete their commands.",
     "test_balance_backup": "Ensures collect_rent backs up balances before processing.",
+    "test_backup_balances_command": "Runs !backup_balances and saves a snapshot.",
     "test_test_bot_dm": "Runs test_bot in silent mode and checks DM output.",
     "test_open_shop_concurrency": "Runs open_shop concurrently to ensure locking.",
 }

--- a/NightCityBot/tests/test_backup_balances_command.py
+++ b/NightCityBot/tests/test_backup_balances_command.py
@@ -1,0 +1,35 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+
+async def run(suite, ctx) -> List[str]:
+    """Run the manual balance backup command."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+
+    member = await suite.get_test_user(ctx)
+    guild = MagicMock()
+    guild.members = [member]
+    ctx.guild = guild
+    ctx.send = AsyncMock()
+
+    saved = {}
+
+    async def fake_save(path, data):
+        saved['path'] = path
+        saved['data'] = data
+
+    with (
+        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 100, "bank": 50})),
+        patch("NightCityBot.cogs.economy.save_json_file", new=fake_save),
+        patch.object(economy, "backup_balances", new=AsyncMock()) as mock_backup,
+    ):
+        await economy.backup_balances_command(ctx)
+        suite.assert_called(logs, mock_backup, "backup_balances")
+
+    if saved.get("data", {}).get(str(member.id)) == {"cash": 100, "bank": 50}:
+        logs.append("✅ balances saved")
+    else:
+        logs.append("❌ balances not saved")
+
+    return logs


### PR DESCRIPTION
## Summary
- fix `backup_balances` command to write a snapshot file and call `backup_balances` with a label
- add tests for manual balance backup command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854971eee18832f96ea449cf494116d