### PR TITLE
Fix balance backup filenames and add single user command

### DIFF
--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -40,6 +40,7 @@ TEST_MODULES = {
     "test_roll_as_user": "Rolls on behalf of another user.",
     "test_message_cleanup": "Ensures !dm and !post delete their commands.",
     "test_balance_backup": "Ensures collect_rent backs up balances before processing.",
+    "test_backup_balance_command": "Runs !backup_balance for a single user.",
     "test_backup_balances_command": "Runs !backup_balances and saves a snapshot.",
     "test_restore_balance_command": "Restores a single user's balance from backup.",
     "test_test_bot_dm": "Runs test_bot in silent mode and checks DM output.",

--- a/NightCityBot/tests/test_backup_balance_command.py
+++ b/NightCityBot/tests/test_backup_balance_command.py
@@ -1,0 +1,30 @@
+from typing import List
+from unittest.mock import AsyncMock, patch
+
+async def run(suite, ctx) -> List[str]:
+    """Back up a single member's balance."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    member = await suite.get_test_user(ctx)
+    ctx.send = AsyncMock()
+
+    saved = {}
+
+    async def fake_save(path, data):
+        saved['path'] = path
+        saved['data'] = data
+
+    with (
+        patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': 100, 'bank': 50})),
+        patch('NightCityBot.cogs.economy.save_json_file', new=fake_save),
+        patch.object(economy, 'backup_balances', new=AsyncMock()) as mock_backup,
+    ):
+        await economy.backup_balance_command(ctx, member)
+        suite.assert_called(logs, mock_backup, 'backup_balances')
+
+    if saved.get('data', {}).get(str(member.id)) == {'cash': 100, 'bank': 50}:
+        logs.append('✅ balance saved')
+    else:
+        logs.append('❌ balance not saved')
+
+    return logs


### PR DESCRIPTION
## Summary
- name per-user backup files using the user ID only
- add `backup_balance` command for backing up an individual member
- test new command and update test registry

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a5d294f0832f95688c306dfd8263