### PR TITLE
Add label-based balance restore option

### DIFF
--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -44,6 +44,8 @@ TEST_MODULES = {
     "test_backup_balances_command": "Runs !backup_balances and saves a snapshot.",
     "test_restore_balance_command": "Restores a single user's balance from backup.",
     "test_restore_balance_latest": "Restores the latest entry from a user's backup log.",
+    "test_restore_balance_label": "Restores a user's balance using a label.",
+    "test_restore_balances_label": "Restores all users' balances using a label.",
     "test_test_bot_dm": "Runs test_bot in silent mode and checks DM output.",
     "test_open_shop_concurrency": "Runs open_shop concurrently to ensure locking.",
 }

--- a/NightCityBot/tests/test_restore_balance_label.py
+++ b/NightCityBot/tests/test_restore_balance_label.py
@@ -1,0 +1,25 @@
+from typing import List
+from unittest.mock import AsyncMock, patch
+
+async def run(suite, ctx) -> List[str]:
+    """Restore a balance using a label from the user's backup log."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    member = await suite.get_test_user(ctx)
+    ctx.send = AsyncMock()
+
+    backup = [
+        {"cash": 50, "bank": 20, "label": "old"},
+        {"cash": 100, "bank": 40, "label": "collect_rent_before"},
+    ]
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("NightCityBot.cogs.economy.load_json_file", new=AsyncMock(return_value=backup)),
+        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 0, "bank": 0})),
+        patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)) as mock_update,
+    ):
+        await economy.restore_balance_command(ctx, member, "collect_rent_before")
+        suite.assert_called(logs, mock_update, "update_balance")
+
+    return logs

--- a/NightCityBot/tests/test_restore_balances_label.py
+++ b/NightCityBot/tests/test_restore_balances_label.py
@@ -1,0 +1,39 @@
+from typing import List
+from unittest.mock import AsyncMock, patch
+from pathlib import Path
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Restore all balances using a label."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    member = await suite.get_test_user(ctx)
+    ctx.send = AsyncMock()
+
+    backup_dir = Path(config.BALANCE_BACKUP_DIR)
+    path1 = backup_dir / f"balance_backup_{member.id}.json"
+    path2 = backup_dir / "balance_backup_123.json"
+
+    backups = {
+        path1: [{"cash": 100, "bank": 50, "label": "collect_rent_before"}],
+        path2: [{"cash": 200, "bank": 0, "label": "collect_rent_before"}],
+    }
+
+    async def fake_load(p, default=None):
+        return backups.get(p, default)
+
+    with (
+        patch("pathlib.Path.glob", return_value=[path1, path2]),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("NightCityBot.cogs.economy.load_json_file", new=AsyncMock(side_effect=fake_load)),
+        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 0, "bank": 0})),
+        patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)) as mock_update,
+    ):
+        await economy.restore_balances_command(ctx, "collect_rent_before")
+        suite.assert_called(logs, mock_update, "update_balance")
+        if mock_update.await_count == 2:
+            logs.append("✅ multiple restores")
+        else:
+            logs.append(f"❌ expected 2 updates got {mock_update.await_count}")
+
+    return logs


### PR DESCRIPTION
## Summary
- add support for restoring balances via label names
- update restore commands accordingly
- add tests for restoring by label

## Testing
- `pip install -q -r ../requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ac13948c832fb59cc313e5b0a9b7