### PR TITLE
Suppress message sending in tests

### DIFF
--- a/NightCityBot/tests/test_open_shop_command.py
+++ b/NightCityBot/tests/test_open_shop_command.py
@@ -21,9 +21,11 @@ async def run(suite, ctx) -> List[str]:
 
         original_channel = ctx.channel
         ctx.channel = correct_channel
+        ctx.send = AsyncMock()
 
         economy = suite.bot.get_cog('Economy')
         await economy.open_shop(ctx)
+        suite.assert_send(logs, ctx.send, "ctx.send")
         logs.append("→ Result: ✅ !open_shop executed in correct channel")
 
         ctx.channel = original_channel

--- a/NightCityBot/tests/test_open_shop_errors.py
+++ b/NightCityBot/tests/test_open_shop_errors.py
@@ -14,10 +14,12 @@ async def run(suite, ctx) -> List[str]:
     economy = suite.bot.get_cog('Economy')
     wrong_channel = ctx.channel
     monday = datetime(2025, 6, 16)
+    ctx.send = AsyncMock()
     with patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock()), \
          patch("NightCityBot.utils.helpers.get_tz_now", return_value=monday):
         # Wrong channel
         await economy.open_shop(ctx)
+        suite.assert_send(logs, ctx.send, "ctx.send")
         logs.append("✅ open_shop rejected outside business channel")
 
         ctx.channel = ctx.guild.get_channel(config.BUSINESS_ACTIVITY_CHANNEL_ID)

--- a/NightCityBot/tests/test_rent_logging_sends.py
+++ b/NightCityBot/tests/test_rent_logging_sends.py
@@ -21,8 +21,12 @@ async def run(suite, ctx) -> List[str]:
         economy = suite.bot.get_cog('Economy')
         with (
             patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+            patch.object(rent_log_channel, "send", new=AsyncMock()) as rent_send,
+            patch.object(eviction_channel, "send", new=AsyncMock()) as evict_send,
         ):
             await economy.simulate_rent(ctx, target_user=user)
+            suite.assert_send(logs, rent_send, "rent_log_channel.send")
+            suite.assert_send(logs, evict_send, "eviction_channel.send")
         logs.append("→ Result: ✅ Rent logic executed and logging channels present.")
     except Exception as e:
         logs.append(f"❌ Exception in test_rent_logging_sends: {e}")


### PR DESCRIPTION
## Summary
- mock `ctx.send` for `open_shop` tests
- intercept log channel sends in `test_rent_logging_sends`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_6854ba9e36ec832f85865f85db462a60