### PR TITLE
Fix !test_bot hang

### DIFF
--- a/NightCityBot/tests/test_full_rent_commands.py
+++ b/NightCityBot/tests/test_full_rent_commands.py
@@ -18,7 +18,9 @@ async def run(suite, ctx) -> List[str]:
         economy = suite.bot.get_cog('Economy')
         cyber = suite.bot.get_cog('CyberwareManager')
         with (
+            patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+            patch.object(cyber.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(cyber.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
             patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),
         ):

--- a/NightCityBot/tests/test_rent_logging_sends.py
+++ b/NightCityBot/tests/test_rent_logging_sends.py
@@ -20,6 +20,7 @@ async def run(suite, ctx) -> List[str]:
 
         economy = suite.bot.get_cog('Economy')
         with (
+            patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
             patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
             patch.object(rent_log_channel, "send", new=AsyncMock()) as rent_send,
             patch.object(eviction_channel, "send", new=AsyncMock()) as evict_send,

--- a/NightCityBot/tests/test_simulate_commands.py
+++ b/NightCityBot/tests/test_simulate_commands.py
@@ -10,7 +10,9 @@ async def run(suite, ctx) -> List[str]:
     admin = suite.bot.get_cog('Admin')
     ctx.send = AsyncMock()
     with (
+        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
         patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+        patch.object(cyber.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
         patch.object(cyber.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
         patch.object(admin, "log_audit", new=AsyncMock()) as mock_audit,
         patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),


### PR DESCRIPTION
## Summary
- patch tests calling `simulate_rent` so they mock `get_balance`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c1e73654832f9b755ccf957bf21c