### PR TITLE
Add Trauma Team assist command

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -48,6 +48,8 @@ from NightCityBot.cogs.system_control import SystemControl
 print("✅ SystemControl imported")
 from NightCityBot.cogs.role_buttons import RoleButtons
 print("✅ RoleButtons imported")
+from NightCityBot.cogs.trauma_team import TraumaTeam
+print("✅ TraumaTeam imported")
 
 print("🔍 Importing startup checks...")
 from NightCityBot.utils.startup_checks import perform_startup_checks
@@ -90,6 +92,7 @@ class NightCityBot(commands.Bot):
         await self.add_cog(CyberwareManager(self))
         await self.add_cog(LOA(self))
         await self.add_cog(RoleButtons(self))
+        await self.add_cog(TraumaTeam(self))
         await self.add_cog(Admin(self))
         await self.add_cog(TestSuite(self))
         # Verify configuration and clean up logs after all cogs are loaded

--- a/NightCityBot/cogs/trauma_team.py
+++ b/NightCityBot/cogs/trauma_team.py
@@ -1,0 +1,30 @@
+import discord
+from discord.ext import commands
+from NightCityBot.utils.constants import TRAUMA_ROLE_COSTS
+import config
+
+
+class TraumaTeam(commands.Cog):
+    """Commands related to Trauma Team assistance."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(aliases=["calltrauma", "trauma"])
+    async def call_trauma(self, ctx: commands.Context) -> None:
+        """Ping the Trauma Team role with the user's plan."""
+        trauma_channel = ctx.guild.get_channel(config.TRAUMA_FORUM_CHANNEL_ID)
+        if not isinstance(trauma_channel, (discord.TextChannel, discord.ForumChannel)):
+            await ctx.send("⚠️ Trauma Team channel not found.")
+            return
+
+        plan_role = next((r for r in ctx.author.roles if r.name in TRAUMA_ROLE_COSTS), None)
+        if not plan_role:
+            await ctx.send("⚠️ You don't have a Trauma Team plan role.")
+            return
+
+        mention = f"<@&{config.TRAUMA_TEAM_ROLE_ID}>"
+        await trauma_channel.send(
+            f"{mention} <@{ctx.author.id}> with **{plan_role.name}** is in need of assistance."
+        )
+        await ctx.send("🚑 Trauma Team notified.")

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -49,6 +49,7 @@ TEST_MODULES = {
     "test_test_bot_dm": "Runs test_bot in silent mode and checks DM output.",
     "test_open_shop_concurrency": "Runs open_shop concurrently to ensure locking.",
     "test_npc_button": "Assign NPC role via button.",
+    "test_call_trauma": "Pings Trauma Team with the user's plan.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_call_trauma.py
+++ b/NightCityBot/tests/test_call_trauma.py
@@ -1,0 +1,25 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure call_trauma pings the Trauma Team channel."""
+    logs: List[str] = []
+    cog = suite.bot.get_cog('TraumaTeam')
+    if not cog:
+        logs.append('❌ TraumaTeam cog not loaded')
+        return logs
+
+    trauma_channel = MagicMock(spec=discord.TextChannel)
+    trauma_channel.send = AsyncMock()
+    with patch.object(ctx.guild, 'get_channel', return_value=trauma_channel):
+        role = MagicMock(spec=discord.Role)
+        role.name = 'Trauma Team Gold'
+        ctx.author.roles = [role]
+        ctx.send = AsyncMock()
+        await cog.call_trauma(ctx)
+    suite.assert_send(logs, trauma_channel.send, 'trauma_channel.send')
+    return logs
+


### PR DESCRIPTION
## Summary
- add `call_trauma` command for requesting assistance
- load `TraumaTeam` cog at startup
- include new self‑test for the command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68589df61af4832f927296948fba171e