### PR TITLE
Add mass checkup role command

### DIFF
--- a/NightCityBot/tests/test_alias_registry.py
+++ b/NightCityBot/tests/test_alias_registry.py
@@ -21,6 +21,7 @@ import pytest
     (Economy, "collect_trauma", ["collecttrauma"]),
     (CyberwareManager, "checkup", ["check-up", "check_up", "cu", "cup"]),
     (CyberwareManager, "weeks_without_checkup", ["weekswithoutcheckup", "wwocup", "wwc"]),
+    (CyberwareManager, "give_checkup_role", ["givecheckuprole", "givecheckups", "cuall", "checkupall"]),
     (SystemControl, "enable_system", ["enablesystem", "es", "systemenable"]),
     (SystemControl, "disable_system", ["disablesystem", "ds", "systemdisable"]),
     (SystemControl, "system_status", ["systemstatus"]),


### PR DESCRIPTION
## Summary
- adjust weekly check to run every Monday
- add `give_checkup_role` command for mass role assignment
- document new command aliases in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859c9cd2aec832f92c4668d9b520ec9