### PR TITLE
Add deficits report command

### DIFF
--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -50,6 +50,7 @@ TEST_MODULES = {
     "test_open_shop_concurrency": "Runs open_shop concurrently to ensure locking.",
     "test_npc_button": "Assign NPC role via button.",
     "test_call_trauma": "Pings Trauma Team with the user's plan.",
+    "test_list_deficits": "Reports members with insufficient funds.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_list_deficits.py
+++ b/NightCityBot/tests/test_list_deficits.py
@@ -1,0 +1,25 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+
+async def run(suite, ctx) -> List[str]:
+    """Check that list_deficits reports users with short funds."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    if not economy:
+        logs.append('❌ Economy cog not loaded')
+        return logs
+
+    user = await suite.get_test_user(ctx)
+    role_h = MagicMock(spec=discord.Role)
+    role_h.name = 'Housing Tier 1'
+    role_b = MagicMock(spec=discord.Role)
+    role_b.name = 'Business Tier 1'
+    user.roles = [role_h, role_b]
+    ctx.guild.members = [user]
+    ctx.send = AsyncMock()
+
+    with patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': 500, 'bank': 0})):
+        await economy.list_deficits(ctx)
+        suite.assert_send(logs, ctx.send, 'ctx.send')
+    return logs

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Main commands:
 * `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown.
 * `!simulate_rent [@user] [-v]` – identical to `!collect_rent` but performs a dry run without updating balances.
+* `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail.
 * `!collect_housing @user [-force]`, `!collect_business @user [-force]`, `!collect_trauma @user [-force]` – immediately charge a single user's housing rent, business rent or Trauma Team subscription. Pass `-force` to override the 30 day limit.
 * `!backup_balances` – save all member balances to a timestamped JSON file. Each
   backup entry records the balance and the `change` since the previous entry.


### PR DESCRIPTION
## Summary
- add `_list_obligations` and `_evaluate_member_funds` helpers
- add `list_deficits` command to report members who can't cover fees
- document the command in README
- include self-test for the new command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608003c6fc832fa01c7b0654940e8c