### PR TITLE
Ensure baseline rent covers all verified members

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -1158,8 +1158,11 @@ class Economy(commands.Cog):
             if target_user and m.id == target_user.id:
                 members_to_process = [m]
                 break
-            if not target_user and any("Tier" in r.name for r in m.roles):
-                members_to_process.append(m)
+            if not target_user:
+                has_verified = any(r.id == config.VERIFIED_ROLE_ID for r in m.roles)
+                has_tier = any("Tier" in r.name for r in m.roles)
+                if has_verified or has_tier:
+                    members_to_process.append(m)
         if not members_to_process:
             await ctx.send("❌ No matching members found.")
             return
@@ -1344,7 +1347,12 @@ class Economy(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def list_deficits(self, ctx) -> None:
         """Show members who cannot pay all upcoming fees."""
-        members = [m for m in ctx.guild.members if any("Tier" in r.name for r in m.roles)]
+        members = [
+            m
+            for m in ctx.guild.members
+            if any("Tier" in r.name for r in m.roles)
+            or any(r.id == config.VERIFIED_ROLE_ID for r in m.roles)
+        ]
         lines: List[str] = []
         for m in members:
             result = await self._evaluate_member_funds(m)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -51,6 +51,7 @@ TEST_MODULES = {
     "test_npc_button": "Assign NPC role via button.",
     "test_call_trauma": "Pings Trauma Team with the user's plan.",
     "test_list_deficits": "Reports members with insufficient funds.",
+    "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_rent_baseline_non_tier.py
+++ b/NightCityBot/tests/test_rent_baseline_non_tier.py
@@ -1,0 +1,36 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+from NightCityBot.utils.constants import BASELINE_LIVING_COST
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure baseline rent is deducted for verified members without Tier roles."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    user = await suite.get_test_user(ctx)
+
+    verified = MagicMock(spec=discord.Role)
+    verified.name = 'Verified'
+    verified.id = config.VERIFIED_ROLE_ID
+    user.roles = [verified]
+    ctx.guild.members = [user]
+    ctx.send = AsyncMock()
+
+    with (
+        patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': BASELINE_LIVING_COST, 'bank': 0})),
+        patch.object(economy.unbelievaboat, 'update_balance', new=AsyncMock(return_value=True)) as mock_update,
+        patch.object(economy, 'backup_balances', new=AsyncMock()),
+        patch('NightCityBot.cogs.economy.load_json_file', new=AsyncMock(return_value={})),
+        patch('NightCityBot.cogs.economy.save_json_file', new=AsyncMock()),
+        patch('pathlib.Path.exists', return_value=False),
+    ):
+        await economy.collect_rent(ctx, target_user=user)
+        suite.assert_called(logs, mock_update, 'update_balance')
+        args = mock_update.await_args_list[0].args
+        if args[0] == user.id and args[1].get('cash') == -BASELINE_LIVING_COST:
+            logs.append('✅ baseline deducted for non-tier user')
+        else:
+            logs.append('❌ baseline deduction not applied correctly')
+
+    return logs


### PR DESCRIPTION
## Summary
- include members with Verified role when selecting rent targets
- update deficit check to cover all verified users
- add regression test for baseline deduction when a user has no Tier roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686080fd0eec832fb1159de7b25bf554