### PR TITLE
Add cyberware flag to simulate_rent

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -1316,15 +1316,20 @@ class Economy(commands.Cog):
     async def simulate_rent(self, ctx, *args, target_user: Optional[discord.Member] = None):
         """Simulate rent collection without applying changes.
 
-        Pass ``-v``/``--verbose`` to include detailed output.
+        Pass ``-v``/``--verbose`` to include detailed output. Use ``-cyberware``
+        to also preview the upcoming cyberware medication cost for ``target_user``.
         """
         verbose = False
+        include_cyber = False
         if target_user is None:
             converter = commands.MemberConverter()
             remaining = []
             for arg in args:
-                if arg.lower() in {"-v", "--verbose", "-verbose", "verbose"}:
+                lower = arg.lower()
+                if lower in {"-v", "--verbose", "-verbose", "verbose"}:
                     verbose = True
+                elif lower in {"-cyberware", "--cyberware", "cyberware"}:
+                    include_cyber = True
                 else:
                     remaining.append(arg)
             for arg in remaining:
@@ -1335,10 +1340,41 @@ class Economy(commands.Cog):
                     continue
         else:
             for arg in args:
-                if arg.lower() in {"-v", "--verbose", "-verbose", "verbose"}:
+                lower = arg.lower()
+                if lower in {"-v", "--verbose", "-verbose", "verbose"}:
                     verbose = True
-                    break
+                elif lower in {"-cyberware", "--cyberware", "cyberware"}:
+                    include_cyber = True
         await self.run_rent_collection(ctx, target_user=target_user, dry_run=True, verbose=verbose)
+
+        if include_cyber and target_user:
+            cyber = self.bot.get_cog('CyberwareManager')
+            if not cyber:
+                await ctx.send("⚠️ Cyberware system not available.")
+            else:
+                guild = ctx.guild
+                checkup = guild.get_role(config.CYBER_CHECKUP_ROLE_ID)
+                medium = guild.get_role(config.CYBER_MEDIUM_ROLE_ID)
+                high = guild.get_role(config.CYBER_HIGH_ROLE_ID)
+                extreme = guild.get_role(config.CYBER_EXTREME_ROLE_ID)
+                level = None
+                if extreme and extreme in target_user.roles:
+                    level = 'extreme'
+                elif high and high in target_user.roles:
+                    level = 'high'
+                elif medium and medium in target_user.roles:
+                    level = 'medium'
+
+                if level:
+                    weeks = cyber.data.get(str(target_user.id), 0)
+                    if checkup and checkup in target_user.roles:
+                        upcoming = weeks + 1
+                        cost = cyber.calculate_cost(level, upcoming)
+                        await ctx.send(f"💊 Cyberware meds week {upcoming}: ${cost}")
+                    else:
+                        await ctx.send("Cyberware checkup due — no med cost")
+                else:
+                    await ctx.send(f"{target_user.display_name} has no cyberware role.")
 
     @commands.command(name="list_deficits")
     @commands.has_permissions(administrator=True)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -51,6 +51,7 @@ TEST_MODULES = {
     "test_npc_button": "Assign NPC role via button.",
     "test_call_trauma": "Pings Trauma Team with the user's plan.",
     "test_list_deficits": "Reports members with insufficient funds.",
+    "test_simulate_rent_cyberware": "Runs simulate_rent with the -cyberware flag.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_simulate_rent_cyberware.py
+++ b/NightCityBot/tests/test_simulate_rent_cyberware.py
@@ -1,0 +1,31 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, patch
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Run simulate_rent with -cyberware flag."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    cyber = suite.bot.get_cog('CyberwareManager')
+    user = await suite.get_test_user(ctx)
+    # Give user a cyberware role and checkup role
+    medium = discord.Object(id=config.CYBER_MEDIUM_ROLE_ID)
+    checkup = discord.Object(id=config.CYBER_CHECKUP_ROLE_ID)
+    user.roles = [medium, checkup]
+    cyber.data[str(user.id)] = 0
+    ctx.send = AsyncMock()
+    with (
+        patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
+        patch.object(economy.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+        patch.object(cyber.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),
+        patch.object(cyber.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+        patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),
+    ):
+        await economy.simulate_rent(ctx, "-cyberware", target_user=user)
+    messages = [c.args[0] for c in ctx.send.await_args_list if c.args]
+    if any("Cyberware meds week" in m for m in messages):
+        logs.append("✅ cyberware cost included")
+    else:
+        logs.append("❌ cyberware cost missing")
+    return logs

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Main commands:
 * `!event_start` – fixers can activate this in the attendance channel to temporarily allow `!attend` and `!open_shop` for four hours outside of Sunday.
 * `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown.
-* `!simulate_rent [@user] [-v]` – identical to `!collect_rent` but performs a dry run without updating balances.
+* `!simulate_rent [@user] [-v] [-cyberware]` – identical to `!collect_rent` but performs a dry run without updating balances. With `-cyberware` the upcoming medication cost for the specified user is also shown.
 * `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail.
 * `!collect_housing @user [-force]`, `!collect_business @user [-force]`, `!collect_trauma @user [-force]` – immediately charge a single user's housing rent, business rent or Trauma Team subscription. Pass `-force` to override the 30 day limit.
 * `!backup_balances` – save all member balances to a timestamped JSON file. Each


### PR DESCRIPTION
## Summary
- extend `!simulate_rent` with `-cyberware` option
- document new flag
- test new behaviour with a self-test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860820178a4832f9409c0aaa474a415