### PR TITLE
Ensure list_deficits always shows progress

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -1382,7 +1382,12 @@ class Economy(commands.Cog):
     @commands.command(name="list_deficits")
     @commands.has_permissions(administrator=True)
     async def list_deficits(self, ctx) -> None:
-        """Show members who cannot pay all upcoming fees."""
+        """Show members who cannot pay all upcoming fees.
+
+        A short message is always sent so staff know the command ran. Failing
+        housing or business rent will result in eviction notices.
+        """
+        await ctx.send("🔎 Checking member funds...")
         members = [
             m
             for m in ctx.guild.members
@@ -1396,10 +1401,16 @@ class Economy(commands.Cog):
                 continue
             _total, deficit, payable, unpaid = result
             if deficit > 0:
-                pay = ", ".join(payable) if payable else "None"
-                fail = ", ".join(unpaid) if unpaid else "None"
+                fail_items: List[str] = []
+                for item in unpaid:
+                    name = item.split(" ($")[0]
+                    if "Housing Tier" in name or "Business Tier" in name:
+                        fail_items.append(f"{name} (eviction)")
+                    else:
+                        fail_items.append(name)
+                fail_desc = ", ".join(fail_items) if fail_items else "None"
                 lines.append(
-                    f"<@{m.id}> short by ${deficit:,}. Can pay: {pay}. Cannot pay: {fail}."
+                    f"{m.display_name} short by ${deficit:,}. Can't pay: {fail_desc}."
                 )
         if lines:
             await ctx.send("\n".join(lines))

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Main commands:
 * `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown.
 * `!simulate_rent [@user] [-v] [-cyberware]` – identical to `!collect_rent` but performs a dry run without updating balances. With `-cyberware` the upcoming medication cost for the specified user is also shown.
-* `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail.
+* `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail. Unpaid housing or business rent is marked "(eviction)".
 * `!collect_housing @user [-force]`, `!collect_business @user [-force]`, `!collect_trauma @user [-force]` – immediately charge a single user's housing rent, business rent or Trauma Team subscription. Pass `-force` to override the 30 day limit.
 * `!backup_balances` – save all member balances to a timestamped JSON file. Each
   backup entry records the balance and the `change` since the previous entry.


### PR DESCRIPTION
## Summary
- clarify `list_deficits` docstring and indicate eviction risk labels
- mark unpaid housing/business items as `(eviction)` and show the failing charges by name
- document eviction note in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686085a1fa70832f9e5ff899017486ab