### PR TITLE
Continue rent eviction if baseline unpaid

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -1217,22 +1217,17 @@ class Economy(commands.Cog):
                     log.append("🔄 Balance check passed." if check else "⚠️ Balance update check failed.")
 
                 if not on_loa:
-                    base_ok, cash, bank = await self.deduct_flat_fee(member, cash, bank, log, BASELINE_LIVING_COST, dry_run=dry_run)
+                    base_ok, cash, bank = await self.deduct_flat_fee(
+                        member, cash, bank, log, BASELINE_LIVING_COST, dry_run=dry_run
+                    )
                     if not base_ok:
-                        if eviction_channel:
-                            if not dry_run:
-                                await eviction_channel.send(
-                                    f"⚠️ <@{member.id}> could not pay baseline living cost (${BASELINE_LIVING_COST})."
-                                )
-                        log.append("❌ Skipping remaining rent steps.")
-                        summary = "\n".join(log)
-                        if verbose:
-                            await ctx.send(summary)
-                        else:
-                            await ctx.send(f"❌ Skipping remaining rent steps for <@{member.id}>")
-                        if dry_run and admin_cog:
-                            await admin_cog.log_audit(ctx.author, summary)
-                        continue
+                        if eviction_channel and not dry_run:
+                            await eviction_channel.send(
+                                f"⚠️ <@{member.id}> could not pay baseline living cost (${BASELINE_LIVING_COST})."
+                            )
+                        log.append(
+                            "⚠️ Baseline living cost unpaid. Continuing with rent steps."
+                        )
 
                 cash, bank = await self.process_housing_rent(member, app_roles, cash, bank, log, rent_log_channel, eviction_channel, dry_run=dry_run) if not on_loa else (cash, bank)
                 cash, bank = await self.process_business_rent(member, app_roles, cash, bank, log, rent_log_channel, eviction_channel, dry_run=dry_run)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -53,6 +53,7 @@ TEST_MODULES = {
     "test_list_deficits": "Reports members with insufficient funds.",
     "test_simulate_rent_cyberware": "Runs simulate_rent with the -cyberware flag.",
     "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
+    "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_eviction_on_baseline_failure.py
+++ b/NightCityBot/tests/test_eviction_on_baseline_failure.py
@@ -1,0 +1,40 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+from NightCityBot.utils.constants import BASELINE_LIVING_COST
+
+async def run(suite, ctx) -> List[str]:
+    """Eviction notices should post even when baseline deduction fails."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    user = await suite.get_test_user(ctx)
+
+    role_h = MagicMock(spec=discord.Role)
+    role_h.name = 'Housing Tier 2'
+    role_b = MagicMock(spec=discord.Role)
+    role_b.name = 'Business Tier 2'
+    user.roles = [role_h, role_b]
+    ctx.guild.members = [user]
+
+    eviction_channel = ctx.guild.get_channel(config.EVICTION_CHANNEL_ID)
+    eviction_channel.send = AsyncMock()
+
+    logs.append('→ Expected: baseline failure should still trigger eviction notices.')
+
+    with (
+        patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': BASELINE_LIVING_COST - 400, 'bank': 0})),
+        patch.object(economy.unbelievaboat, 'update_balance', new=AsyncMock(return_value=True)),
+        patch.object(economy, 'backup_balances', new=AsyncMock()),
+        patch.object(economy.trauma_service, 'process_trauma_team_payment', new=AsyncMock()),
+        patch('NightCityBot.cogs.economy.load_json_file', new=AsyncMock(return_value={})),
+        patch('NightCityBot.cogs.economy.save_json_file', new=AsyncMock()),
+        patch('pathlib.Path.exists', return_value=False),
+    ):
+        await economy.collect_rent(ctx, target_user=user)
+        eviction_calls = eviction_channel.send.await_args_list
+        if len(eviction_calls) >= 3:
+            logs.append('✅ eviction notices sent for baseline, housing and business')
+        else:
+            logs.append('❌ eviction notices missing')
+    return logs

--- a/NightCityBot/tests/test_pytest_eviction.py
+++ b/NightCityBot/tests/test_pytest_eviction.py
@@ -1,0 +1,61 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+from discord.ext import commands
+import config
+from NightCityBot.cogs.economy import Economy
+from NightCityBot.cogs.test_suite import TestSuite
+from NightCityBot.tests.test_eviction_on_baseline_failure import run as run_eviction
+
+class DummyBot:
+    def __init__(self):
+        self.cogs = {}
+        self.loop = asyncio.new_event_loop()
+    def add_cog(self, cog):
+        self.cogs[cog.__class__.__name__] = cog
+        for attr in dir(cog):
+            cmd = getattr(cog, attr)
+            if isinstance(cmd, commands.Command):
+                cmd.cog = cog
+    def get_cog(self, name):
+        return self.cogs.get(name)
+
+class DummyCtx:
+    def __init__(self):
+        self.guild = MagicMock()
+        self.guild.get_member.return_value = MagicMock(id=config.TEST_USER_ID)
+        self.guild.fetch_member = AsyncMock(return_value=MagicMock(id=config.TEST_USER_ID))
+        self.eviction_channel = MagicMock(spec=discord.TextChannel)
+        self.rent_log_channel = MagicMock(spec=discord.TextChannel)
+        def channel_lookup(cid):
+            if cid == config.EVICTION_CHANNEL_ID:
+                return self.eviction_channel
+            if cid == config.RENT_LOG_CHANNEL_ID:
+                return self.rent_log_channel
+            return MagicMock(spec=discord.TextChannel)
+        self.guild.get_channel.side_effect = channel_lookup
+        self.author = MagicMock(roles=[], display_name="Author")
+        self.channel = MagicMock()
+        self.send = AsyncMock()
+        self.message = MagicMock(attachments=[])
+
+
+def setup_suite():
+    bot = DummyBot()
+    with patch("NightCityBot.services.unbelievaboat.aiohttp.ClientSession", new=MagicMock()):
+        econ = Economy(bot)
+    bot.add_cog(econ)
+    ts = TestSuite(bot)
+    bot.add_cog(ts)
+    return ts
+
+
+def run_test(func):
+    suite = setup_suite()
+    ctx = DummyCtx()
+    return asyncio.run(func(suite, ctx))
+
+
+def test_eviction_on_baseline_failure():
+    logs = run_test(run_eviction)
+    assert all("❌" not in l for l in logs), f"Logs: {logs}"


### PR DESCRIPTION
## Summary
- allow rent collection to continue after baseline living deduction fails
- verify eviction notices on baseline failure
- register new test in the test suite

## Testing
- `pytest NightCityBot/tests/test_pytest_eviction.py -q`
- `pytest NightCityBot/tests/test_alias_registry.py NightCityBot/tests/test_pytest_loa.py NightCityBot/tests/test_pytest_eviction.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a7f0c970832f81b9a80c6e0c6837