### PR TITLE
Update deficit docs and test

### DIFF
--- a/NightCityBot/tests/test_list_deficits.py
+++ b/NightCityBot/tests/test_list_deficits.py
@@ -1,13 +1,15 @@
 from typing import List
 import discord
 from unittest.mock import AsyncMock, MagicMock, patch
+import config
 
 async def run(suite, ctx) -> List[str]:
     """Check that list_deficits reports users with short funds."""
     logs: List[str] = []
     economy = suite.bot.get_cog('Economy')
-    if not economy:
-        logs.append('❌ Economy cog not loaded')
+    cyber = suite.bot.get_cog('CyberwareManager')
+    if not economy or not cyber:
+        logs.append('❌ required cogs not loaded')
         return logs
 
     user = await suite.get_test_user(ctx)
@@ -15,11 +17,23 @@ async def run(suite, ctx) -> List[str]:
     role_h.name = 'Housing Tier 1'
     role_b = MagicMock(spec=discord.Role)
     role_b.name = 'Business Tier 1'
-    user.roles = [role_h, role_b]
+    medium = discord.Object(id=config.CYBER_MEDIUM_ROLE_ID)
+    checkup = discord.Object(id=config.CYBER_CHECKUP_ROLE_ID)
+    user.roles = [role_h, role_b, medium, checkup]
+    cyber.data[str(user.id)] = 0
     ctx.guild.members = [user]
     ctx.send = AsyncMock()
 
     with patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': 500, 'bank': 0})):
         await economy.list_deficits(ctx)
         suite.assert_send(logs, ctx.send, 'ctx.send')
+        msg = ctx.send.await_args[0][0]
+        if (
+            'Housing Tier 1' in msg
+            and 'Business Tier 1' in msg
+            and 'Cyberware meds week 1' in msg
+        ):
+            logs.append('✅ unpaid items listed')
+        else:
+            logs.append(f'❌ unexpected message: {msg}')
     return logs

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Main commands:
 * `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown.
 * `!simulate_rent [@user] [-v] [-cyberware]` – identical to `!collect_rent` but performs a dry run without updating balances. With `-cyberware` the upcoming medication cost for the specified user is also shown.
-* `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail. Unpaid housing or business rent is marked "(eviction)".
+* `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail. Unpaid housing or business rent is marked "(eviction)". Cyberware medication costs are included and all failing items are shown together.
 * `!collect_housing @user [-force]`, `!collect_business @user [-force]`, `!collect_trauma @user [-force]` – immediately charge a single user's housing rent, business rent or Trauma Team subscription. Pass `-force` to override the 30 day limit.
 * `!backup_balances` – save all member balances to a timestamped JSON file. Each
   backup entry records the balance and the `change` since the previous entry.


### PR DESCRIPTION
## Summary
- document that `!list_deficits` shows all failed charges including cyberware
- extend self-test to verify the command lists housing, business and cyberware items

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860aee875ac832f92f78ffe2ebfa246