### PR TITLE
Add DM summary for rent and !last_payment command

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ NPC_ROLE_ID = 1348661508011462769
 THREAD_MAP_FILE = "thread_map.json"
 OPEN_LOG_FILE = "business_open_log.json"
 LAST_RENT_FILE = "last_rent.json"
+LAST_PAYMENT_FILE = "last_payment.json"
 BALANCE_BACKUP_DIR = "backups"
 RENT_AUDIT_DIR = "rent_audits"
 ATTEND_LOG_FILE = "attendance_log.json"


### PR DESCRIPTION
## Summary
- notify members with a DM whenever rent is processed
- keep a record of the most recent payment for each member
- add `!last_payment` command to view the stored details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860b6a5e5f0832fb15f9b047631a737