### PR TITLE
Fix help embed overflow

### DIFF
--- a/NightCityBot/__init__.py
+++ b/NightCityBot/__init__.py
@@ -1,0 +1,21 @@
+"""NightCityBot package setup."""
+
+from __future__ import annotations
+
+import discord
+
+# Original send method reference for patching in tests
+orig_send = discord.abc.Messageable.send
+
+async def _chunked_send(self: discord.abc.Messageable, content: str | None = None, **kwargs):
+    """Send long messages in 1900-character chunks."""
+    if isinstance(content, str) and len(content) > 1900 and not kwargs.get("embed") and not kwargs.get("embeds"):
+        for chunk in (content[i : i + 1900] for i in range(0, len(content), 1900)):
+            await orig_send(self, chunk, **kwargs)
+        return
+    await orig_send(self, content=content, **kwargs)
+
+# Patch globally
+discord.abc.Messageable.send = _chunked_send
+
+__all__ = ["orig_send"]

--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -198,14 +198,17 @@ class Admin(commands.Cog):
             color=discord.Color.purple(),
         )
         for name, value in fields:
-            if embed_len(current) + len(name) + len(value) > 5800:
-                current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
-                embeds.append(current)
-                current = discord.Embed(
-                    title="🛠️ NCRP Bot — Fixer & Admin Help (cont.)",
-                    color=discord.Color.purple(),
-                )
-            current.add_field(name=name, value=value, inline=False)
+            chunks = [value[i : i + 1024] for i in range(0, len(value), 1024)] or [""]
+            for i, chunk in enumerate(chunks):
+                field_name = name if i == 0 else "\u200b"
+                if embed_len(current) + len(field_name) + len(chunk) > 5800:
+                    current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
+                    embeds.append(current)
+                    current = discord.Embed(
+                        title="🛠️ NCRP Bot — Fixer & Admin Help (cont.)",
+                        color=discord.Color.purple(),
+                    )
+                current.add_field(name=field_name, value=chunk, inline=False)
 
         current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
         embeds.append(current)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -55,6 +55,8 @@ TEST_MODULES = {
     "test_simulate_all": "Runs the combined simulate_all command.",
 
     "test_log_audit_chunks": "Ensures long audit entries are split across fields.",
+    "test_helpfixer_chunks": "Ensures long help entries are split across fields.",
+    "test_send_chunks": "Ensures long plain messages are chunked automatically.",
     "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
     "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",
 }

--- a/NightCityBot/tests/test_helpfixer_chunks.py
+++ b/NightCityBot/tests/test_helpfixer_chunks.py
@@ -1,0 +1,22 @@
+from typing import List
+from unittest.mock import AsyncMock
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure helpfixer splits long sections into valid chunks."""
+    logs: List[str] = []
+    admin = suite.bot.get_cog('Admin')
+    ctx.send = AsyncMock()
+    await admin.helpfixer(ctx)
+    try:
+        ctx.send.assert_awaited()
+        for call in ctx.send.await_args_list:
+            embed = call.kwargs.get('embed') or call.args[0]
+            if any(len(field.value) > 1024 for field in embed.fields):
+                logs.append('❌ field overflow')
+                break
+        else:
+            logs.append('✅ chunks used')
+    except Exception as e:
+        logs.append(f'❌ exception {e}')
+    return logs
+

--- a/NightCityBot/tests/test_send_chunks.py
+++ b/NightCityBot/tests/test_send_chunks.py
@@ -1,0 +1,21 @@
+from typing import List
+from unittest.mock import AsyncMock, patch
+import discord
+import NightCityBot
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure long plain messages are split automatically."""
+    logs: List[str] = []
+    send_mock = AsyncMock()
+    with patch('NightCityBot.orig_send', new=send_mock):
+        await discord.abc.Messageable.send(object(), 'A' * 5000)
+    try:
+        send_mock.assert_awaited()
+        calls = send_mock.await_args_list
+        if len(calls) >= 3 and all(len(c.args[1]) <= 1900 for c in calls):
+            logs.append('✅ chunks used')
+        else:
+            logs.append('❌ not chunked')
+    except Exception as e:
+        logs.append(f'❌ exception {e}')
+    return logs


### PR DESCRIPTION
## Summary
- avoid exceeding Discord's 1024-char limit per field in `!helpfixer`
- added regression test for help embed chunking
- patch `Messageable.send` to chunk any long text automatically
- added test covering the patched send method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860c82c5730832f9ae1d7d1c9613b9f