### PR TITLE
Improve rent simulation output

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -1201,6 +1201,7 @@ class Economy(commands.Cog):
         dry_run: bool = False,
         verbose: bool = False,
         force: bool = False,
+        preview_dm: bool = False,
     ):
         """Internal helper for rent collection and simulation.
 
@@ -1386,6 +1387,10 @@ class Economy(commands.Cog):
                     f"📊 {'Projected' if dry_run else 'Final'} balance — Cash: ${cash:,}, Bank: ${bank:,}, Total: {(cash or 0) + (bank or 0):,}"
                 )
 
+                if dry_run and preview_dm:
+                    log.append("💌 Would DM summary to user.")
+                    log.append("📝 Would record last_payment entry.")
+
                 summary = "\n".join(log)
                 if verbose:
                     await ctx.send(summary)
@@ -1507,7 +1512,11 @@ class Economy(commands.Cog):
                 elif lower in {"-cyberware", "--cyberware", "cyberware"}:
                     include_cyber = True
         await self.run_rent_collection(
-            ctx, target_user=target_user, dry_run=True, verbose=verbose
+            ctx,
+            target_user=target_user,
+            dry_run=True,
+            verbose=verbose,
+            preview_dm=target_user is not None,
         )
 
         if include_cyber and target_user:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Main commands:
 * `!event_start` – fixers can activate this in the attendance channel to temporarily allow `!attend` and `!open_shop` for four hours outside of Sunday.
 * `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown.
-* `!simulate_rent [@user] [-v] [-cyberware]` – identical to `!collect_rent` but performs a dry run without updating balances. With `-cyberware` the upcoming medication cost for the specified user is also shown.
-* `!simulate_all [@user]` – run both rent and cyberware simulations together for the specified user or everyone.
+* `!simulate_rent [@user] [-v] [-cyberware]` – identical to `!collect_rent` but performs a dry run without updating balances. When a user is specified the output notes that a DM and last_payment entry would be created. With `-cyberware` the upcoming medication cost for the specified user is also shown.
+* `!simulate_all [@user]` – run both simulations at once. When a user is given the rent output indicates that a DM and last_payment entry would be created.
 * `!list_deficits` – list members who can't cover upcoming fees, how much they're short and which charges would fail. Unpaid housing or business rent is marked "(eviction)". Cyberware medication costs are included and all failing items are shown together.
 * `!collect_housing @user [-force]`, `!collect_business @user [-force]`, `!collect_trauma @user [-force]` – immediately charge a single user's housing rent, business rent or Trauma Team subscription. Pass `-force` to override the 30 day limit.
 * `!backup_balances` – save all member balances to a timestamped JSON file. Each


### PR DESCRIPTION
## Summary
- show DM and last-payment preview lines in rent simulations
- mention DM preview in README docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860ddfa8098832f8b2a641a060ba2a2