### PR TITLE
Allow fixers to use !start_rp

### DIFF
--- a/NightCityBot/cogs/rp_manager.py
+++ b/NightCityBot/cogs/rp_manager.py
@@ -41,7 +41,7 @@ class RPManager(commands.Cog):
     @commands.command(
         aliases=["startrp", "rp_start", "rpstart"]
     )
-    @commands.has_permissions(administrator=True)
+    @commands.check_any(is_fixer(), commands.has_permissions(administrator=True))
     async def start_rp(self, ctx, *user_identifiers: str):
         """Starts a private RP channel for the mentioned users."""
         guild = ctx.guild

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All data is stored in `cyberware_log.json`.
 
 Provides tools for creating private RP text channels and archiving them when complete.
 
-* `!start_rp @users` – create a private text channel for the mentioned users. The channel name is generated automatically using `utils.helpers.build_channel_name` and only the participants and staff can view it.
+* `!start_rp @users` – fixers and admins can create a private text channel for the mentioned users. The channel name is generated automatically using `utils.helpers.build_channel_name` and only the participants and staff can view it.
 * `!end_rp` – once the scene is finished, this command archives the entire channel into the group audit forum and deletes the original channel.
 * Any command typed inside a `text-rp-*` channel is relayed back to the bot, so players can roll dice or trigger other commands without leaving the RP session.
 


### PR DESCRIPTION
## Summary
- permit fixers to create RP channels by checking the Fixer role in `start_rp`
- clarify README that fixers and admins can start RP sessions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621cdf6608832fa98df800e17efa50