### PR TITLE
Add cyberware weekly report

### DIFF
--- a/NightCityBot/tests/test_alias_registry.py
+++ b/NightCityBot/tests/test_alias_registry.py
@@ -22,6 +22,7 @@ import pytest
     (CyberwareManager, "checkup", ["check-up", "check_up", "cu", "cup"]),
     (CyberwareManager, "weeks_without_checkup", ["weekswithoutcheckup", "wwocup", "wwc"]),
     (CyberwareManager, "give_checkup_role", ["givecheckuprole", "givecheckups", "cuall", "checkupall"]),
+    (CyberwareManager, "collect_cyberware", ["collectcyberware"]),
     (SystemControl, "enable_system", ["enablesystem", "es", "systemenable"]),
     (SystemControl, "disable_system", ["disablesystem", "ds", "systemdisable"]),
     (SystemControl, "system_status", ["systemstatus"]),

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Commands:
 * `!checkup @user` – ripperdoc command to remove the weekly check‑up role from a player after their in‑character medical exam, resetting their streak to zero.
 * `!weeks_without_checkup @user` – show how many weeks the specified player has kept the check‑up role without visiting a ripperdoc.
 * `!give_checkup_role [@user]` – give the check-up role to a member or all cyberware users.
+* `!checkup_report` – list who did a checkup last week, who paid their meds and who couldn't pay.
+* `!collect_cyberware @user` – manually charge a member for their meds unless they already paid or did a checkup this week.
 
-All data is stored in `cyberware_log.json`.
+All data is stored in `cyberware_log.json`. Weekly results are appended to `cyberware_weekly.json`.
 
 ### RPManager
 *File: `NightCityBot/cogs/rp_manager.py`*

--- a/config.py
+++ b/config.py
@@ -43,6 +43,7 @@ BALANCE_BACKUP_DIR = "backups"
 RENT_AUDIT_DIR = "rent_audits"
 ATTEND_LOG_FILE = "attendance_log.json"
 CYBERWARE_LOG_FILE = "cyberware_log.json"
+CYBERWARE_WEEKLY_FILE = "cyberware_weekly.json"
 SYSTEM_STATUS_FILE = "system_status.json"
 CYBER_CHECKUP_ROLE_ID = 1383623743934300272
 CYBER_MEDIUM_ROLE_ID = 1383623573939159240

--- a/scripts/generate_test_data.py
+++ b/scripts/generate_test_data.py
@@ -5,6 +5,7 @@ FILES = [
     'attendance_log.json',
     'business_open_log.json',
     'cyberware_log.json',
+    'cyberware_weekly.json',
     'system_status.json',
     'thread_map.json',
 ]


### PR DESCRIPTION
## Summary
- log weekly checkup results to `cyberware_weekly.json`
- add `!checkup_report` command
- support new config setting
- maintain test-data script
- **add `collect_cyberware` manual command**

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68623722e16c832fbf069ad68f469b27