### PR TITLE
Fix JSON loading when log files are empty

### DIFF
--- a/NightCityBot/utils/helpers.py
+++ b/NightCityBot/utils/helpers.py
@@ -36,7 +36,13 @@ async def load_json_file(file_path: Path | str, default=None):
     try:
         if path.exists():
             async with aiofiles.open(path, 'r') as f:
-                return json.loads(await f.read())
+                content = await f.read()
+                if not content.strip():
+                    return default if default is not None else {}
+                return json.loads(content)
+    except json.JSONDecodeError as e:
+        # File had invalid JSON; treat as empty and log without traceback
+        logger.error("Invalid JSON in %s: %s", path.name, e)
     except Exception as e:
         logger.exception("Error loading %s: %s", path.name, e)
     return default if default is not None else {}


### PR DESCRIPTION
## Summary
- gracefully handle empty or corrupted JSON log files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_686468db68ec832fa9a18d7bd70a1df1