### PR TITLE
Refactor deduction logic

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -45,6 +45,13 @@ class Economy(commands.Cog):
         self.attend_lock = asyncio.Lock()
         self.event_expires_at: Optional[datetime] = None
 
+    @staticmethod
+    def _split_deduction(cash: int, amount: int) -> tuple[int, int]:
+        """Return cash/bank portions ensuring negative cash isn't double counted."""
+        cash_deduct = min(max(cash, 0), amount)
+        bank_deduct = max(0, amount - cash_deduct)
+        return cash_deduct, bank_deduct
+
     def event_active(self) -> bool:
         """Return ``True`` if a fixer event is currently active."""
         if self.event_expires_at is None:
@@ -759,8 +766,7 @@ class Economy(commands.Cog):
             )
             return False, cash, bank
 
-        deduct_cash = min(max(cash, 0), amount)
-        deduct_bank = max(0, amount - deduct_cash)
+        deduct_cash, deduct_bank = self._split_deduction(cash, amount)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash
@@ -823,8 +829,7 @@ class Economy(commands.Cog):
             )
             return cash, bank
 
-        deduct_cash = min(max(cash, 0), housing_total)
-        deduct_bank = max(0, housing_total - deduct_cash)
+        deduct_cash, deduct_bank = self._split_deduction(cash, housing_total)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash
@@ -896,8 +901,7 @@ class Economy(commands.Cog):
             )
             return cash, bank
 
-        deduct_cash = min(max(cash, 0), business_total)
-        deduct_bank = max(0, business_total - deduct_cash)
+        deduct_cash, deduct_bank = self._split_deduction(cash, business_total)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash

--- a/NightCityBot/services/trauma_team.py
+++ b/NightCityBot/services/trauma_team.py
@@ -8,6 +8,13 @@ class TraumaTeamService:
     def __init__(self, bot):
         self.bot = bot
 
+    @staticmethod
+    def _split_deduction(cash: int, amount: int) -> tuple[int, int]:
+        """Return cash and bank portions ensuring negative cash is ignored."""
+        cash_deduct = min(max(cash, 0), amount)
+        bank_deduct = max(0, amount - cash_deduct)
+        return cash_deduct, bank_deduct
+
     async def process_trauma_team_payment(
             self,
             member: discord.Member,
@@ -86,8 +93,7 @@ class TraumaTeamService:
                 log.append("❌ Insufficient funds for Trauma payment.")
             return
 
-        cash_deduct = min(max(cash, 0), cost)
-        bank_deduct = max(0, cost - cash_deduct)
+        cash_deduct, bank_deduct = self._split_deduction(cash, cost)
         payload = {
             "cash": -cash_deduct,
             "bank": -bank_deduct,

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -60,6 +60,7 @@ TEST_MODULES = {
     "test_send_chunks": "Ensures long plain messages are chunked automatically.",
     "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
     "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",
+    "test_negative_cash": "Handles baseline deduction when cash is negative.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_negative_cash.py
+++ b/NightCityBot/tests/test_negative_cash.py
@@ -1,0 +1,38 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+from NightCityBot.utils.constants import BASELINE_LIVING_COST
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure negative cash doesn't double deduct the baseline fee."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    user = await suite.get_test_user(ctx)
+
+    verified = MagicMock(spec=discord.Role)
+    verified.name = 'Verified'
+    verified.id = config.VERIFIED_ROLE_ID
+    user.roles = [verified]
+    ctx.guild.members = [user]
+    ctx.send = AsyncMock()
+
+    cash = -2503
+    bank = 4335
+    with (
+        patch.object(economy.unbelievaboat, 'get_balance', new=AsyncMock(return_value={'cash': cash, 'bank': bank})),
+        patch.object(economy.unbelievaboat, 'update_balance', new=AsyncMock(return_value=True)) as mock_update,
+        patch.object(economy, 'backup_balances', new=AsyncMock()),
+        patch('NightCityBot.cogs.economy.load_json_file', new=AsyncMock(return_value={})),
+        patch('NightCityBot.cogs.economy.save_json_file', new=AsyncMock()),
+        patch('pathlib.Path.exists', return_value=False),
+    ):
+        await economy.collect_rent(ctx, target_user=user)
+        suite.assert_called(logs, mock_update, 'update_balance')
+        args = mock_update.await_args_list[0].args
+        payload = args[1]
+        if payload.get('bank') == -BASELINE_LIVING_COST and 'cash' not in payload:
+            logs.append('✅ negative cash handled correctly')
+        else:
+            logs.append(f'❌ unexpected payload: {payload}')
+    return logs

--- a/NightCityBot/tests/test_pytest_negative_cash.py
+++ b/NightCityBot/tests/test_pytest_negative_cash.py
@@ -1,0 +1,59 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+from discord.ext import commands
+import config
+from NightCityBot.cogs.economy import Economy
+from NightCityBot.cogs.test_suite import TestSuite
+from NightCityBot.tests.test_negative_cash import run as run_negative
+
+class DummyBot:
+    def __init__(self):
+        self.cogs = {}
+        self.loop = asyncio.new_event_loop()
+    def add_cog(self, cog):
+        self.cogs[cog.__class__.__name__] = cog
+        for attr in dir(cog):
+            cmd = getattr(cog, attr)
+            if isinstance(cmd, commands.Command):
+                cmd.cog = cog
+    def get_cog(self, name):
+        return self.cogs.get(name)
+
+def setup_suite():
+    bot = DummyBot()
+    with patch("NightCityBot.services.unbelievaboat.aiohttp.ClientSession", new=MagicMock()):
+        econ = Economy(bot)
+    bot.add_cog(econ)
+    ts = TestSuite(bot)
+    bot.add_cog(ts)
+    return ts
+
+class DummyCtx:
+    def __init__(self):
+        self.guild = MagicMock()
+        self.guild.get_member.return_value = MagicMock(id=config.TEST_USER_ID)
+        self.guild.fetch_member = AsyncMock(return_value=MagicMock(id=config.TEST_USER_ID))
+        self.eviction_channel = MagicMock(spec=discord.TextChannel)
+        self.rent_log_channel = MagicMock(spec=discord.TextChannel)
+        def channel_lookup(cid):
+            if cid == config.EVICTION_CHANNEL_ID:
+                return self.eviction_channel
+            if cid == config.RENT_LOG_CHANNEL_ID:
+                return self.rent_log_channel
+            return MagicMock(spec=discord.TextChannel)
+        self.guild.get_channel.side_effect = channel_lookup
+        self.author = MagicMock(roles=[], display_name="Author")
+        self.channel = MagicMock()
+        self.send = AsyncMock()
+        self.message = MagicMock(attachments=[])
+
+def run_test(func):
+    suite = setup_suite()
+    ctx = DummyCtx()
+    return asyncio.run(func(suite, ctx))
+
+
+def test_negative_cash():
+    logs = run_test(run_negative)
+    assert all("❌" not in l for l in logs), f"Logs: {logs}"


### PR DESCRIPTION
## Summary
- refactor deduction logic to avoid double-charging negative cash
- use the helper for baseline, housing, business, and trauma team deductions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686471164564832fae44a466c73f00a8