### PR TITLE
Rename trauma backup labels

### DIFF
--- a/NightCityBot/services/trauma_team.py
+++ b/NightCityBot/services/trauma_team.py
@@ -101,14 +101,14 @@ class TraumaTeamService:
         success = True
         economy = self.bot.get_cog("Economy")
         if not dry_run and economy:
-            await economy.backup_balances([member], label="cyberware_before")
+            await economy.backup_balances([member], label="trauma_before")
             success = await economy.unbelievaboat.update_balance(
                 member.id,
                 payload,
                 reason="Trauma Team Subscription",
             )
             if success:
-                await economy.backup_balances([member], label="cyberware_after")
+                await economy.backup_balances([member], label="trauma_after")
 
         if success:
             if not dry_run and target_thread:


### PR DESCRIPTION
## Summary
- rename labels used for Trauma Team payments
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a8afb114832faadc3adf3c64a8d1