### PR TITLE
Move deduction logic to helpers

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -19,6 +19,7 @@ from NightCityBot.utils.constants import (
     TRAUMA_ROLE_COSTS,
 )
 from NightCityBot.utils import helpers
+from NightCityBot.utils.helpers import split_deduction
 
 safe_filename = helpers.safe_filename
 
@@ -45,12 +46,6 @@ class Economy(commands.Cog):
         self.attend_lock = asyncio.Lock()
         self.event_expires_at: Optional[datetime] = None
 
-    @staticmethod
-    def _split_deduction(cash: int, amount: int) -> tuple[int, int]:
-        """Return cash/bank portions ensuring negative cash isn't double counted."""
-        cash_deduct = min(max(cash, 0), amount)
-        bank_deduct = max(0, amount - cash_deduct)
-        return cash_deduct, bank_deduct
 
     def event_active(self) -> bool:
         """Return ``True`` if a fixer event is currently active."""
@@ -766,7 +761,7 @@ class Economy(commands.Cog):
             )
             return False, cash, bank
 
-        deduct_cash, deduct_bank = self._split_deduction(cash, amount)
+        deduct_cash, deduct_bank = split_deduction(cash, amount)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash
@@ -829,7 +824,7 @@ class Economy(commands.Cog):
             )
             return cash, bank
 
-        deduct_cash, deduct_bank = self._split_deduction(cash, housing_total)
+        deduct_cash, deduct_bank = split_deduction(cash, housing_total)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash
@@ -901,7 +896,7 @@ class Economy(commands.Cog):
             )
             return cash, bank
 
-        deduct_cash, deduct_bank = self._split_deduction(cash, business_total)
+        deduct_cash, deduct_bank = split_deduction(cash, business_total)
         payload: Dict[str, int] = {}
         if deduct_cash > 0:
             payload["cash"] = -deduct_cash

--- a/NightCityBot/services/trauma_team.py
+++ b/NightCityBot/services/trauma_team.py
@@ -1,6 +1,7 @@
 from typing import Optional, List
 import discord
 from NightCityBot.utils.constants import TRAUMA_ROLE_COSTS
+from NightCityBot.utils.helpers import split_deduction
 import config
 
 
@@ -8,12 +9,6 @@ class TraumaTeamService:
     def __init__(self, bot):
         self.bot = bot
 
-    @staticmethod
-    def _split_deduction(cash: int, amount: int) -> tuple[int, int]:
-        """Return cash and bank portions ensuring negative cash is ignored."""
-        cash_deduct = min(max(cash, 0), amount)
-        bank_deduct = max(0, amount - cash_deduct)
-        return cash_deduct, bank_deduct
 
     async def process_trauma_team_payment(
             self,
@@ -93,7 +88,7 @@ class TraumaTeamService:
                 log.append("❌ Insufficient funds for Trauma payment.")
             return
 
-        cash_deduct, bank_deduct = self._split_deduction(cash, cost)
+        cash_deduct, bank_deduct = split_deduction(cash, cost)
         payload = {
             "cash": -cash_deduct,
             "bank": -bank_deduct,

--- a/NightCityBot/utils/helpers.py
+++ b/NightCityBot/utils/helpers.py
@@ -71,3 +71,10 @@ def get_tz_now() -> datetime:
     """Return current time in the configured timezone."""
     tz = ZoneInfo(getattr(config, "TIMEZONE", "UTC"))
     return datetime.now(tz)
+
+
+def split_deduction(cash: int, amount: int) -> tuple[int, int]:
+    """Return cash/bank portions ensuring negative cash isn't double counted."""
+    cash_deduct = min(max(cash, 0), amount)
+    bank_deduct = max(0, amount - cash_deduct)
+    return cash_deduct, bank_deduct


### PR DESCRIPTION
## Summary
- centralize split_deduction helper in utils
- use new helper in Economy cog and TraumaTeamService

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a8b39888832f9068f87e73c931f8