### PR TITLE
Add verbose output helper

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -1,11 +1,27 @@
-print("🔥 BOT.PY: Starting imports...")
+"""Main entry point for the NightCityBot Discord bot."""
+
+# ----------------------------------------------------------------------------
+# Verbose logging helper
+# ----------------------------------------------------------------------------
+
+# Standard library imports
+import os
+
+# Enable verbose output when the VERBOSE environment variable is truthy.
+VERBOSE = os.getenv("VERBOSE", "false").lower() in {"1", "true", "yes", "y"}
+
+
+def vprint(*args, **kwargs) -> None:
+    """Print only when VERBOSE is enabled."""
+    if VERBOSE:
+        print(*args, **kwargs)
+
+vprint("🔥 BOT.PY: Starting imports...")
 
 import discord
 print("✅ discord imported")
 from discord.ext import commands
 print("✅ discord.ext.commands imported")
-import os
-print("✅ os imported")
 import sys
 print("✅ sys imported")
 import logging


### PR DESCRIPTION
## Summary
- add a VERBOSE flag and `vprint` helper to `bot.py`
- remove redundant `os` import

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d73526dc832f94357ea1cbe88bae