### PR TITLE
Fix NameError on startup

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -1,5 +1,4 @@
 import os
-vprint("✅ os imported")
 
 # Allow debug logging of the startup sequence when the VERBOSE environment
 # variable is truthy.  Missing definitions previously caused a NameError when
@@ -11,6 +10,8 @@ def vprint(*args, **kwargs):
     """Conditionally print when ``VERBOSE`` is enabled."""
     if VERBOSE:
         print(*args, **kwargs)
+
+vprint("✅ os imported")
 
 vprint("🔥 BOT.PY: Starting imports...")
 


### PR DESCRIPTION
## Summary
- initialize `VERBOSE` and `vprint` before logging import of `os`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d907a114832fa588595a1cc2c0ef