### PR TITLE
Fix undefined logger

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -1,5 +1,4 @@
 import os
-vprint("✅ os imported")
 
 # Allow debug logging of the startup sequence when the VERBOSE environment
 # variable is truthy.  Missing definitions previously caused a NameError when
@@ -12,8 +11,7 @@ def vprint(*args, **kwargs):
     if VERBOSE:
         print(*args, **kwargs)
 
-vprint("🔥 BOT.PY: Starting imports...")
-
+vprint("✅ os imported")
 
 vprint("🔥 BOT.PY: Starting imports...")
 import discord
@@ -24,6 +22,9 @@ import sys
 vprint("✅ sys imported")
 import logging
 vprint("✅ logging imported")
+
+# Use a module-level logger for startup logging
+logger = logging.getLogger(__name__)
 
 vprint("🔍 Setting up Python path...")
 # Ensure the package root is on the path when executed as a script


### PR DESCRIPTION
## Summary
- define `logger` after importing `logging`
- keep imports debug logging message

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865d907a114832fa588595a1cc2c0ef