### PR TITLE
Handle unknown user errors in DM relay

### DIFF
--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -129,7 +129,13 @@ class DMHandler(commands.Cog):
         if not any(getattr(r, "name", "") == config.FIXER_ROLE_NAME for r in roles):
             return
 
-        target_user = await self.bot.fetch_user(int(user_id))
+        try:
+            target_user = await self.bot.fetch_user(int(user_id))
+        except discord.NotFound:
+            logger.warning("DM relay failed: unknown user %s", user_id)
+            self.dm_threads.pop(user_id, None)
+            await save_json_file(config.THREAD_MAP_FILE, self.dm_threads)
+            return
         if not target_user:
             return
 

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -34,6 +34,7 @@ TEST_MODULES = {
     "test_dm_roll_command": "Relays a roll through !dm.",
     "test_dm_userid": "Ensures !dm works with a raw user ID.",
     "test_dm_thread_autolink": "Links DM threads from their name when missing.",
+    "test_dm_unknown_user": "Handles missing user ID when relaying from DM thread.",
     "test_start_rp_multi": "Starts RP with two users and ends it.",
     "test_cyberware_weekly": "Simulates the weekly cyberware task.",
     "test_loa_fixer_other": "Fixer starts and ends LOA for another user.",

--- a/NightCityBot/tests/test_dm_unknown_user.py
+++ b/NightCityBot/tests/test_dm_unknown_user.py
@@ -1,0 +1,33 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Handle missing user IDs gracefully."""
+    logs: List[str] = []
+    dm_handler = suite.bot.get_cog('DMHandler')
+    user = await suite.get_test_user(ctx)
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 9999
+    thread.name = f"{user.name}-{user.id}"
+    message = MagicMock()
+    message.channel = thread
+    message.content = "Hello"
+    message.attachments = []
+    fixer_role = MagicMock()
+    fixer_role.name = config.FIXER_ROLE_NAME
+    message.author = MagicMock(roles=[fixer_role], display_name="Fixer", id=1)
+    message.delete = AsyncMock()
+
+    dm_handler.dm_threads[str(user.id)] = thread.id
+
+    notfound = discord.NotFound(MagicMock(), {"message": "Unknown"})
+    with patch.object(dm_handler.bot, 'fetch_user', new=AsyncMock(side_effect=notfound)):
+        await dm_handler.handle_thread_message(message)
+
+    if str(user.id) not in dm_handler.dm_threads:
+        logs.append("✅ Unknown user handled gracefully")
+    else:
+        logs.append("❌ Unknown user mapping not removed")
+    return logs


### PR DESCRIPTION
## Summary
- handle `discord.NotFound` when relaying from DM threads
- add regression test for unknown user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867145cf454832fb391335ca6abac14