### PR TITLE
Remove netrunner roll bonus

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -103,7 +103,6 @@ class Admin(commands.Cog):
             value=(
                 "`!roll [XdY+Z]` – roll dice using standard notation, e.g. `!roll 2d6+1`. "
                 "Mention another user to roll for them.\n"
-                "Netrunner Level 2 grants +1 and Level 3 grants +2 to the total. "
                 "Rolls made in DMs are recorded in your private log thread."
             ),
             inline=False,

--- a/NightCityBot/cogs/roll_system.py
+++ b/NightCityBot/cogs/roll_system.py
@@ -81,21 +81,12 @@ class RollSystem(commands.Cog):
         sides = int(sides)
         mod = int(mod) if mod else 0
 
-        role_names = [getattr(r, "name", "") for r in getattr(author, "roles", [])]
-        bonus = (
-            2
-            if "Netrunner Level 3" in role_names
-            else 1 if "Netrunner Level 2" in role_names else 0
-        )
-
         rolls = [random.randint(1, sides) for _ in range(n_dice)]
-        total = sum(rolls) + mod + bonus
+        total = sum(rolls) + mod
 
         name = author.display_name
         header = f'🎲 {name} rolled: {n_dice}d{sides}{f"+{mod}" if mod else ""}\n'
         body = f'**Results:** {", ".join(map(str, rolls))}\n**Total:** {total}'
-        if bonus:
-            body += f" (includes +{bonus} Netrunner bonus)"
         result = header + body
 
         await channel.send(result)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -11,7 +11,7 @@ TEST_MODULES = {
     "test_post_executes_command": "Sends a `!roll` command into a channel using `!post`.",
     "test_post_roll_execution": "Executes a roll via !post and checks result inside RP channel.",
     "test_rolls": "Runs `!roll` with valid and invalid input and checks result.",
-    "test_bonus_rolls": "Checks that Netrunner bonuses are applied correctly.",
+    "test_bonus_rolls": "Ensures Netrunner roles do not grant bonus rolls.",
     "test_full_rent_commands": "Executes rent collection on a live user and verifies balance updates.",
     "test_passive_income_logic": "Applies passive income based on recent shop opens.",
     "test_trauma_payment": "Attempts to log a trauma plan subscription in the correct DM thread.",

--- a/NightCityBot/tests/test_bonus_rolls.py
+++ b/NightCityBot/tests/test_bonus_rolls.py
@@ -5,7 +5,7 @@ import config
 from NightCityBot.utils.constants import ROLE_COSTS_BUSINESS, ROLE_COSTS_HOUSING
 
 async def run(suite, ctx) -> List[str]:
-    """Test roll bonuses for Netrunner roles."""
+    """Ensure Netrunner roles no longer grant roll bonuses."""
     logs = []
     mock_author = AsyncMock(spec=discord.Member)
     mock_author.display_name = "BonusTest"
@@ -16,16 +16,16 @@ async def run(suite, ctx) -> List[str]:
     channel = AsyncMock(spec=discord.TextChannel)
     channel.send = AsyncMock()
 
-    logs.append("→ Expected: Roll result should include '+1 Netrunner bonus' in output.")
+    logs.append("→ Expected: Roll result should not include 'Netrunner bonus' in output.")
 
     try:
         roll_system = suite.bot.get_cog('RollSystem')
         await roll_system.loggable_roll(mock_author, channel, "1d20")
         message = channel.send.call_args[0][0]
-        if "+1 Netrunner bonus" in message:
-            logs.append("→ Result: ✅ Found bonus text in roll output.")
+        if "Netrunner bonus" in message:
+            logs.append("→ Result: ❌ Bonus text found in roll output.")
         else:
-            logs.append("→ Result: ❌ Bonus text missing from roll output.")
+            logs.append("→ Result: ✅ No bonus text in roll output.")
     except Exception as e:
         logs.append(f"❌ Exception in test_bonus_rolls: {e}")
     return logs

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ Simple dice rolling logic supporting `XdY+Z` syntax. Rolls can be used in any ch
 
 Highlights:
 
-* Applies a netrunner bonus based on the user's roles.
 * Logs DM rolls back to the user's logging thread for record keeping.
 * Supports rolling on behalf of another user when invoked via `!post` or `!dm`.
 


### PR DESCRIPTION
## Summary
- remove netrunner bonus logic from `roll_system`
- update help text about dice rolls
- update README highlights
- adjust bonus rolls test to ensure no bonus is applied

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868d4256ee0832fb6c7f01ec155115e