### PR TITLE
Add helpadmin command

### DIFF
--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -182,13 +182,6 @@ class Admin(commands.Cog):
                     "`!paydue [-v]` – pay your monthly obligations early.",
                     "`!collect_rent [@user] [-v] [-force]` (alias: !collectrent) – run the monthly rent cycle. Use `-force` to ignore the 30\u202fday limit.",
                     "`!collect_housing @user [-v] [-force]` / `!collect_business @user [-v] [-force]` / `!collect_trauma @user [-v] [-force]` – charge specific fees with optional verbose logs. (aliases: !collecthousing / !collectbusiness / !collecttrauma)",
-                    "`!simulate_rent [@user] [-v]` (alias: !simulaterent) – perform a dry run of rent collection using the same options.",
-                    "`!simulate_cyberware [@user] [week]` – preview cyberware medication costs globally or for a certain week.",
-                    "`!simulate_all [@user]` – run both simulations at once.",
-                    "`!backup_balances` – save all member balances to a timestamped file.",
-                    "`!backup_balance @user` – save one member's balance to a file.",
-                    "`!restore_balances <file>` – restore balances from a backup file.",
-                    "`!restore_balance @user [file]` – restore one member's balance from a backup.",
                     "`!list_deficits` – list members who can't cover upcoming charges.",
                 ]),
             ),
@@ -202,6 +195,46 @@ class Admin(commands.Cog):
                     "`!paycyberware [-v]` – pay your own cyberware meds manually.",
                 ]),
             ),
+        ]
+
+        embeds = []
+        current = discord.Embed(
+            title="🛠️ NCRP Bot — Fixer Help",
+            description="Advanced commands for messaging, RP management, and rent.",
+            color=discord.Color.purple(),
+        )
+        for name, value in fields:
+            chunks = [value[i : i + 1024] for i in range(0, len(value), 1024)] or [""]
+            for i, chunk in enumerate(chunks):
+                field_name = name if i == 0 else "\u200b"
+                if embed_len(current) + len(field_name) + len(chunk) > 5800:
+                    current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
+                    embeds.append(current)
+                    current = discord.Embed(
+                        title="🛠️ NCRP Bot — Fixer Help (cont.)",
+                        color=discord.Color.purple(),
+                    )
+                current.add_field(name=field_name, value=chunk, inline=False)
+
+        current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
+        embeds.append(current)
+
+        for e in embeds:
+            await ctx.send(embed=e)
+
+    @commands.command(name="helpadmin")
+    async def helpadmin(self, ctx):
+        """Display help for administrators."""
+
+        def embed_len(e: discord.Embed) -> int:
+            total = len(e.title or "") + len(e.description or "")
+            if e.footer and e.footer.text:
+                total += len(e.footer.text)
+            for f in e.fields:
+                total += len(f.name) + len(str(f.value))
+            return total
+
+        fields = [
             (
                 "⚙️ System Control",
                 "\n".join([
@@ -217,13 +250,25 @@ class Admin(commands.Cog):
                     "`!test__bot [pattern]` – run the PyTest suite optionally filtering by pattern.",
                 ]),
             ),
+            (
+                "💵 Simulations & Backups",
+                "\n".join([
+                    "`!simulate_rent [@user] [-v]` (alias: !simulaterent) – perform a dry run of rent collection using the same options.",
+                    "`!simulate_cyberware [@user] [week]` – preview cyberware medication costs globally or for a certain week.",
+                    "`!simulate_all [@user]` – run both simulations at once.",
+                    "`!backup_balances` – save all member balances to a timestamped file.",
+                    "`!backup_balance @user` – save one member's balance to a file.",
+                    "`!restore_balances <file>` – restore balances from a backup file.",
+                    "`!restore_balance @user [file]` – restore one member's balance from a backup.",
+                ]),
+            ),
         ]
 
         embeds = []
         current = discord.Embed(
-            title="🛠️ NCRP Bot — Fixer & Admin Help",
-            description="Advanced commands for messaging, RP management, rent, and testing.",
-            color=discord.Color.purple(),
+            title="🛠️ NCRP Bot — Admin Help",
+            description="Commands for admins only.",
+            color=discord.Color.dark_gold(),
         )
         for name, value in fields:
             chunks = [value[i : i + 1024] for i in range(0, len(value), 1024)] or [""]
@@ -233,8 +278,8 @@ class Admin(commands.Cog):
                     current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
                     embeds.append(current)
                     current = discord.Embed(
-                        title="🛠️ NCRP Bot — Fixer & Admin Help (cont.)",
-                        color=discord.Color.purple(),
+                        title="🛠️ NCRP Bot — Admin Help (cont.)",
+                        color=discord.Color.dark_gold(),
                     )
                 current.add_field(name=field_name, value=chunk, inline=False)
 

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -27,7 +27,7 @@ TEST_MODULES = {
     "test_cyberware_costs": "Ensures cyberware medication costs scale and cap correctly.",
     "test_loa_commands": "Runs start_loa and end_loa commands.",
     "test_checkup_command": "Runs the ripperdoc !checkup command.",
-    "test_help_commands": "Executes !helpme and !helpfixer.",
+    "test_help_commands": "Executes !helpme, !helpfixer and !helpadmin.",
     "test_post_dm_channel": "Runs !post from a DM thread.",
     "test_post_roll_as_user": "Executes a roll as another user via !post.",
     "test_dm_plain": "Sends a normal anonymous DM using !dm.",
@@ -58,6 +58,7 @@ TEST_MODULES = {
 
     "test_log_audit_chunks": "Ensures long audit entries are split across fields.",
     "test_helpfixer_chunks": "Ensures long help entries are split across fields.",
+    "test_helpadmin_chunks": "Ensures admin help entries are split across fields.",
     "test_send_chunks": "Ensures long plain messages are chunked automatically.",
     "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
     "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",

--- a/NightCityBot/tests/test_help_commands.py
+++ b/NightCityBot/tests/test_help_commands.py
@@ -11,8 +11,9 @@ async def run(suite, ctx) -> List[str]:
     ctx.send = AsyncMock()
     await admin.helpme(ctx)
     await admin.helpfixer(ctx)
-    if ctx.send.await_count >= 2:
-        logs.append("✅ helpme and helpfixer executed")
+    await admin.helpadmin(ctx)
+    if ctx.send.await_count >= 3:
+        logs.append("✅ help commands executed")
     else:
         logs.append("❌ Help commands failed")
     return logs

--- a/NightCityBot/tests/test_helpadmin_chunks.py
+++ b/NightCityBot/tests/test_helpadmin_chunks.py
@@ -1,0 +1,21 @@
+from typing import List
+from unittest.mock import AsyncMock
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure helpadmin splits long sections into valid chunks."""
+    logs: List[str] = []
+    admin = suite.bot.get_cog('Admin')
+    ctx.send = AsyncMock()
+    await admin.helpadmin(ctx)
+    try:
+        ctx.send.assert_awaited()
+        for call in ctx.send.await_args_list:
+            embed = call.kwargs.get('embed') or call.args[0]
+            if any(len(field.value) > 1024 for field in embed.fields):
+                logs.append('❌ field overflow')
+                break
+        else:
+            logs.append('✅ chunks used')
+    except Exception as e:
+        logs.append(f'❌ exception {e}')
+    return logs

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Commands:
 Offers helper commands for staff and global error handling.
 
 * `!post <channel> <message>` – send a message or execute a command in another channel or thread. If `<message>` begins with `!`, the command is run as if it were typed in that location.
-* `!helpme` and `!helpfixer` – show the built in help embeds. The former lists player commands while the latter documents every fixer and admin command with available options.
+* `!helpme`, `!helpfixer` and `!helpadmin` – show the built in help embeds. `!helpme` lists player commands, `!helpfixer` covers fixer tools, and `!helpadmin` documents administrator-only features.
 * `!backfill_logs [limit]` – rebuild `attendance_log.json` and `business_open_log.json` by scanning recent messages. Only successful command usages are recorded. The optional limit controls how many messages are parsed (default 1000).
 * All sensitive actions are logged via `log_audit` to the channel defined by `AUDIT_LOG_CHANNEL_ID`.
 


### PR DESCRIPTION
## Summary
- split admin-only help to a new `!helpadmin` command
- trim advanced options from `!helpfixer`
- document the new help command in README
- extend tests for help commands and add new checks for admin help chunks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c51e76528832fa4996dbb4f565fd5