### PR TITLE
Implement character thread utilities

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -1,14 +1,19 @@
 print("🔥 BOT.PY: Starting imports...")
 
 import discord
+
 print("✅ discord imported")
 from discord.ext import commands
+
 print("✅ discord.ext.commands imported")
 import os
+
 print("✅ os imported")
 import sys
+
 print("✅ sys imported")
 import logging
+
 print("✅ logging imported")
 
 print("🔍 Setting up Python path...")
@@ -21,44 +26,63 @@ if package_root not in sys.path:
 
 print("🔍 Importing config...")
 import config
+
 print("✅ config imported")
 
 print("🔍 Importing utils...")
 from NightCityBot.utils.permissions import is_fixer
+
 print("✅ permissions imported")
 
 print("🔍 Importing cogs...")
 from NightCityBot.cogs.dm_handling import DMHandler
+
 print("✅ DMHandler imported")
 from NightCityBot.cogs.economy import Economy
+
 print("✅ Economy imported")
 from NightCityBot.cogs.rp_manager import RPManager
+
 print("✅ RPManager imported")
 from NightCityBot.cogs.roll_system import RollSystem
+
 print("✅ RollSystem imported")
 from NightCityBot.cogs.admin import Admin
+
 print("✅ Admin imported")
 from NightCityBot.cogs.test_suite import TestSuite
+
 print("✅ TestSuite imported")
 from NightCityBot.cogs.cyberware import CyberwareManager
+
 print("✅ CyberwareManager imported")
 from NightCityBot.cogs.loa import LOA
+
 print("✅ LOA imported")
+from NightCityBot.cogs.character_manager import CharacterManager
+
+print("✅ CharacterManager imported")
 from NightCityBot.cogs.system_control import SystemControl
+
 print("✅ SystemControl imported")
 from NightCityBot.cogs.role_buttons import RoleButtons
+
 print("✅ RoleButtons imported")
 from NightCityBot.cogs.trauma_team import TraumaTeam
+
 print("✅ TraumaTeam imported")
 
 print("🔍 Importing startup checks...")
 from NightCityBot.utils.startup_checks import perform_startup_checks
+
 print("✅ startup_checks imported")
 
 print("🔍 Importing Flask...")
 from flask import Flask
+
 print("✅ Flask imported")
 from threading import Thread
+
 print("✅ Thread imported")
 
 print("🎉 ALL IMPORTS COMPLETED SUCCESSFULLY!")
@@ -76,11 +100,7 @@ class NightCityBot(commands.Bot):
         intents.members = True
         intents.dm_messages = True
 
-        super().__init__(
-            command_prefix="!",
-            help_command=None,
-            intents=intents
-        )
+        super().__init__(command_prefix="!", help_command=None, intents=intents)
 
     async def setup_hook(self):
         # Load all cogs
@@ -91,6 +111,7 @@ class NightCityBot(commands.Bot):
         await self.add_cog(RollSystem(self))
         await self.add_cog(CyberwareManager(self))
         await self.add_cog(LOA(self))
+        await self.add_cog(CharacterManager(self))
         await self.add_cog(RoleButtons(self))
         await self.add_cog(TraumaTeam(self))
         await self.add_cog(Admin(self))
@@ -101,13 +122,15 @@ class NightCityBot(commands.Bot):
     async def on_message(self, message: discord.Message):
         if message.author == self.user or message.author.bot:
             return
-        dm_handler = self.get_cog('DMHandler')
+        dm_handler = self.get_cog("DMHandler")
         if dm_handler and isinstance(message.channel, discord.Thread):
-            if message.channel.id in getattr(dm_handler, 'dm_threads', {}).values():
+            if message.channel.id in getattr(dm_handler, "dm_threads", {}).values():
                 # Let DMHandler process without invoking commands to avoid duplicates
                 return
 
-        if isinstance(message.channel, discord.TextChannel) and message.channel.name.startswith("text-rp-"):
+        if isinstance(
+            message.channel, discord.TextChannel
+        ) and message.channel.name.startswith("text-rp-"):
             # RPManager handles command invocation for text RP channels
             return
 
@@ -115,21 +138,21 @@ class NightCityBot(commands.Bot):
 
     async def on_ready(self):
         logger.info("%s is running!", self.user.name)
-        admin = self.get_cog('Admin')
+        admin = self.get_cog("Admin")
         if admin:
             await admin.log_audit(self.user, "✅ Bot started and ready.")
 
 
-app = Flask('')
+app = Flask("")
 
 
-@app.route('/')
+@app.route("/")
 def home():
     return "Bot is alive Version 1.2!"
 
 
 def run_flask():
-    app.run(host='0.0.0.0', port=5000)
+    app.run(host="0.0.0.0", port=5000)
 
 
 def keep_alive():
@@ -139,20 +162,22 @@ def keep_alive():
 
 def main():
     # Add startup logging
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     print("🚀 Starting NightCityBot initialization...")
     logger.info("Starting NightCityBot...")
-    
+
     # Check token
     print(f"🔑 Checking for Discord token...")
     if not config.TOKEN:
         print("❌ No Discord token found! Please set TOKEN in Secrets.")
         logger.error("❌ No Discord token found! Please set TOKEN in Secrets.")
         return
-    
+
     print("✅ Token found!")
     logger.info("✅ Token found, connecting to Discord...")
-    
+
     # Initialize bot
     print("🤖 Creating bot instance...")
     try:
@@ -162,7 +187,7 @@ def main():
         print(f"❌ Failed to create bot instance: {e}")
         logger.error(f"❌ Failed to create bot instance: {e}")
         return
-    
+
     # Start keep-alive server
     print("🌐 Starting keep-alive server...")
     try:
@@ -171,7 +196,7 @@ def main():
     except Exception as e:
         print(f"❌ Failed to start keep-alive server: {e}")
         logger.error(f"❌ Failed to start keep-alive server: {e}")
-    
+
     # Connect to Discord
     print("🔗 Connecting to Discord...")
     try:
@@ -183,6 +208,7 @@ def main():
         print(f"❌ Bot startup failed: {e}")
         logger.error(f"❌ Bot startup failed: {e}")
         import traceback
+
         traceback.print_exc()
 
 

--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -141,6 +141,16 @@ class Admin(commands.Cog):
             inline=False,
         )
 
+        embed.add_field(
+            name="📑 Character Sheets",
+            value=(
+                "`!search_characters <keyword>` – search all character sheets with fuzzy matching (Fixers only).\n"
+                "`!retire` – move threads tagged 'Retired' to the archive (Fixers only).\n"
+                "`!unretire <thread_id>` – move a retired thread back (Fixers only)."
+            ),
+            inline=False,
+        )
+
         embed.set_footer(text="Use !roll, pay your rent, stay alive.")
         await ctx.send(embed=embed)
 

--- a/NightCityBot/cogs/character_manager.py
+++ b/NightCityBot/cogs/character_manager.py
@@ -1,0 +1,133 @@
+import difflib
+import discord
+from discord.ext import commands
+from NightCityBot.utils.permissions import is_fixer
+import config
+
+
+class CharacterManager(commands.Cog):
+    """Manage character sheet threads."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _move_thread(
+        self, thread: discord.Thread, destination: discord.ForumChannel
+    ) -> None:
+        """Move ``thread`` to ``destination`` forum channel."""
+        await thread._state.http.edit_channel(thread.id, parent_id=str(destination.id))
+
+    async def _iter_all_threads(self, forum: discord.ForumChannel):
+        """Yield all threads from ``forum`` including archived ones."""
+        for t in forum.threads:
+            yield t
+        async for t in forum.archived_threads(limit=None):
+            yield t
+
+    def _match(self, query: str, text: str) -> bool:
+        q = query.lower()
+        t = text.lower()
+        if q in t:
+            return True
+        return difflib.SequenceMatcher(None, q, t).ratio() > 0.6
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    @commands.command()
+    @is_fixer()
+    async def retire(self, ctx: commands.Context) -> None:
+        """Move all threads tagged "Retired" to the retired forum."""
+        src = ctx.guild.get_channel(config.CHARACTER_SHEETS_CHANNEL_ID)
+        dest = ctx.guild.get_channel(config.RETIRED_SHEETS_CHANNEL_ID)
+        if not isinstance(src, discord.ForumChannel) or not isinstance(
+            dest, discord.ForumChannel
+        ):
+            await ctx.send("⚠️ Character forums not configured.")
+            return
+        retired_tag = discord.utils.get(src.available_tags, name="Retired")
+        if not retired_tag:
+            await ctx.send("⚠️ 'Retired' tag not found.")
+            return
+        moved = 0
+        async for thread in self._iter_all_threads(src):
+            if any(tag.id == retired_tag.id for tag in thread.applied_tags):
+                await self._move_thread(thread, dest)
+                moved += 1
+        await ctx.send(f"✅ Moved {moved} thread(s) to {dest.name}.")
+
+    @commands.command()
+    @is_fixer()
+    async def unretire(self, ctx: commands.Context, thread_id: int) -> None:
+        """Move a single thread back to the main forum."""
+        src = ctx.guild.get_channel(config.CHARACTER_SHEETS_CHANNEL_ID)
+        dest = ctx.guild.get_channel(config.RETIRED_SHEETS_CHANNEL_ID)
+        if not isinstance(src, discord.ForumChannel) or not isinstance(
+            dest, discord.ForumChannel
+        ):
+            await ctx.send("⚠️ Character forums not configured.")
+            return
+        try:
+            thread = await self.bot.fetch_channel(thread_id)
+        except discord.NotFound:
+            await ctx.send("❌ Thread not found.")
+            return
+        if not isinstance(thread, discord.Thread) or thread.parent_id != dest.id:
+            await ctx.send("❌ Invalid thread ID.")
+            return
+        await self._move_thread(thread, src)
+        await ctx.send(f"✅ {thread.name} moved back to {src.name}.")
+
+    @commands.command(aliases=["sheet_search", "search_sheets"])
+    @is_fixer()
+    async def search_characters(self, ctx: commands.Context, *, keyword: str) -> None:
+        """Search character sheets for ``keyword``."""
+        forums = []
+        for cid in (
+            config.CHARACTER_SHEETS_CHANNEL_ID,
+            config.RETIRED_SHEETS_CHANNEL_ID,
+        ):
+            ch = ctx.guild.get_channel(cid)
+            if isinstance(ch, discord.ForumChannel):
+                forums.append(ch)
+        if not forums:
+            await ctx.send("⚠️ Character forums not configured.")
+            return
+        matches: list[tuple[discord.Thread, str]] = []
+        for forum in forums:
+            async for thread in self._iter_all_threads(forum):
+                async for msg in thread.history(limit=20, oldest_first=True):
+                    if msg.content and self._match(keyword, msg.content):
+                        text = msg.content
+                        loc = text.lower().find(keyword.lower())
+                        if loc != -1:
+                            start = max(0, loc - 30)
+                            end = loc + len(keyword) + 30
+                            snippet = text[start:end]
+                        else:
+                            snippet = text[:60]
+                        matches.append((thread, snippet))
+                        break
+                if len(matches) >= 10:
+                    break
+            if len(matches) >= 10:
+                break
+        if not matches:
+            await ctx.send("No results found.")
+            return
+        embed = discord.Embed(
+            title=f"Results for '{keyword}'", color=discord.Color.blurple()
+        )
+        for th, snippet in matches:
+            url = (
+                th.jump_url
+                if hasattr(th, "jump_url")
+                else f"https://discord.com/channels/{th.guild.id}/{th.id}"
+            )
+            embed.add_field(name=th.name, value=f"{snippet}\n{url}", inline=False)
+        await ctx.send(embed=embed)

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -55,7 +55,6 @@ TEST_MODULES = {
     "test_list_deficits": "Reports members with insufficient funds.",
     "test_simulate_rent_cyberware": "Runs simulate_rent with the -cyberware flag.",
     "test_simulate_all": "Runs the combined simulate_all command.",
-
     "test_log_audit_chunks": "Ensures long audit entries are split across fields.",
     "test_helpfixer_chunks": "Ensures long help entries are split across fields.",
     "test_helpadmin_chunks": "Ensures admin help entries are split across fields.",
@@ -63,6 +62,7 @@ TEST_MODULES = {
     "test_rent_baseline_non_tier": "Baseline living cost deducted for members without Tier roles.",
     "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",
     "test_negative_cash": "Handles baseline deduction when cash is negative.",
+    "test_character_manager": "Moves retired threads and searches sheets.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_character_manager.py
+++ b/NightCityBot/tests/test_character_manager.py
@@ -1,0 +1,78 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+import config
+
+
+async def run(suite, ctx) -> List[str]:
+    """Test retire/unretire and search commands."""
+    logs: List[str] = []
+    cog = suite.bot.get_cog("CharacterManager")
+    if not cog:
+        logs.append("❌ CharacterManager cog not loaded")
+        return logs
+
+    retired_tag = MagicMock(id=1, name="Retired")
+    src_forum = MagicMock(spec=discord.ForumChannel)
+    dest_forum = MagicMock(spec=discord.ForumChannel)
+    src_forum.available_tags = [retired_tag]
+    src_forum.name = "Chars"
+    dest_forum.name = "Retired"
+    dest_forum.id = 99
+    src_forum.id = 42
+
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 555
+    thread.name = "Example"
+    thread.applied_tags = [retired_tag]
+
+    async def iter_threads(_):
+        yield thread
+
+    with patch.object(
+        ctx.guild,
+        "get_channel",
+        side_effect=lambda cid: (
+            src_forum if cid == config.CHARACTER_SHEETS_CHANNEL_ID else dest_forum
+        ),
+    ), patch.object(cog, "_iter_all_threads", iter_threads), patch.object(
+        cog, "_move_thread", new=AsyncMock()
+    ) as mock_move:
+        ctx.send = AsyncMock()
+        await cog.retire(ctx)
+        suite.assert_called(logs, mock_move, "_move_thread")
+
+    with patch.object(
+        cog.bot, "fetch_channel", new=AsyncMock(return_value=thread)
+    ), patch.object(cog, "_move_thread", new=AsyncMock()) as mock_move2, patch.object(
+        ctx.guild,
+        "get_channel",
+        side_effect=lambda cid: (
+            src_forum if cid == config.CHARACTER_SHEETS_CHANNEL_ID else dest_forum
+        ),
+    ):
+        ctx.send = AsyncMock()
+        thread.parent_id = dest_forum.id
+        await cog.unretire(ctx, thread.id)
+        suite.assert_called(logs, mock_move2, "_move_thread")
+
+    message = MagicMock()
+    message.content = "Johnny Silverhand is legendary."
+
+    async def history(*args, **kwargs):
+        yield message
+
+    thread.history = history
+
+    with patch.object(cog, "_iter_all_threads", iter_threads), patch.object(
+        ctx.guild,
+        "get_channel",
+        side_effect=lambda cid: (
+            src_forum if cid == config.CHARACTER_SHEETS_CHANNEL_ID else dest_forum
+        ),
+    ):
+        ctx.send = AsyncMock()
+        await cog.search_characters(ctx, keyword="silver")
+        suite.assert_send(logs, ctx.send, "send")
+
+    return logs

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ Manages Leave‑of‑Absence status.
 * `!start_loa` and `!end_loa` – players may place themselves on LOA to pause monthly fees and Trauma Team billing. Fixers can provide a user mention to toggle LOA for someone else.
 * While a player is on LOA, the economy cog automatically skips baseline costs, housing rent and Trauma Team payments until `!end_loa` is used.
 
+### CharacterManager
+*File: `NightCityBot/cogs/character_manager.py`*
+
+Utilities for the character sheet forums.
+
+* `!retire` – move all threads tagged "Retired" from the main sheet forum to the retired forum. *(Fixers only)*
+* `!unretire <thread id>` – move a specific thread back to the main forum. *(Fixers only)*
+* `!search_characters <keyword>` – fuzzy, case-insensitive search across all character sheets. *(Fixers only)*
+
 ### RoleButtons
 *File: `NightCityBot/cogs/role_buttons.py`*
 

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 # Automatically load variables from a `.env` file located next to this
 # config module so local development doesn't require exporting them.
 BASE_DIR = Path(__file__).resolve().parent
-load_dotenv(BASE_DIR / '.env')
+load_dotenv(BASE_DIR / ".env")
 
 # Secrets can be provided via environment variables.  They default to ``None``
 # so running the bot locally can still work if these values are assigned below
@@ -56,3 +56,5 @@ RIPPERDOC_ROLE_ID = 1356028868103897156
 RIPPERDOC_LOG_CHANNEL_ID = 1389028820463521802
 TIMEZONE = "America/Los_Angeles"
 RP_IC_CATEGORY_ID = 1348605939527192576
+CHARACTER_SHEETS_CHANNEL_ID = 1366901669316657224
+RETIRED_SHEETS_CHANNEL_ID = 1392690680358244523


### PR DESCRIPTION
## Summary
- add CharacterManager cog for moving and searching character sheet threads
- load CharacterManager in bot startup
- configure character sheet forum IDs
- include a test for retiring/unretiring and searching
- restrict character commands to Fixers
- document commands in README and `!helpme`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f25a91200832f8a836ff761fa41a2