### PR TITLE
Fix character sheet thread move

### DIFF
--- a/NightCityBot/cogs/character_manager.py
+++ b/NightCityBot/cogs/character_manager.py
@@ -38,7 +38,9 @@ class CharacterManager(commands.Cog):
         Returns ``True`` if the thread was moved successfully.
         """
         try:
-            await thread.edit(parent_id=destination.id)
+            await thread._state.http.edit_channel(
+                thread.id, parent_id=str(destination.id)
+            )
         except Exception as e:  # discord.Forbidden, discord.NotFound, HTTPException
             logger.warning(
                 "Failed to move thread %s (%s) to %s: %s",


### PR DESCRIPTION
## Summary
- fix `_move_thread` to use low level HTTP call for setting `parent_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68718046be6c832f86dd8962465f232a