### PR TITLE
Fix retired thread archiving

### DIFF
--- a/NightCityBot/tests/test_character_manager.py
+++ b/NightCityBot/tests/test_character_manager.py
@@ -35,12 +35,13 @@ async def run(suite, ctx) -> List[str]:
         side_effect=lambda cid: (
             src_forum if cid == config.CHARACTER_SHEETS_CHANNEL_ID else dest_forum
         ),
-    ), patch.object(cog, "_iter_all_threads", iter_threads), patch.object(
-        cog, "_move_thread", new=AsyncMock()
-    ) as mock_move:
+    ), patch.object(cog, "_iter_all_threads", iter_threads):
+        dest_forum.create_thread = AsyncMock(return_value=MagicMock(spec=discord.Thread))
+        thread.delete = AsyncMock()
         ctx.send = AsyncMock()
         await cog.retire(ctx)
-        suite.assert_called(logs, mock_move, "_move_thread")
+        suite.assert_called(logs, dest_forum.create_thread, "create_thread")
+        suite.assert_called(logs, thread.delete, "thread.delete")
 
     with patch.object(
         cog.bot, "fetch_channel", new=AsyncMock(return_value=thread)


### PR DESCRIPTION
## Summary
- copy retired threads instead of moving them
- test that `!retire` creates and deletes threads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687188c3d120832fae387ca9e6f6c7b6