### PR TITLE
Add attachment support to !backup_sheets

### DIFF
--- a/NightCityBot/cogs/character_manager.py
+++ b/NightCityBot/cogs/character_manager.py
@@ -312,6 +312,7 @@ class CharacterManager(commands.Cog):
                             "author": getattr(msg.author, "display_name", ""),
                             "content": msg.content or "",
                             "created_at": msg.created_at.isoformat(),
+                            "attachments": [a.url for a in msg.attachments],
                         }
                     )
 

--- a/NightCityBot/tests/test_backup_sheets_command.py
+++ b/NightCityBot/tests/test_backup_sheets_command.py
@@ -24,6 +24,9 @@ async def run(suite, ctx) -> List[str]:
     msg.author.display_name = 'Tester'
     msg.content = 'Hello'
     msg.created_at = datetime.utcnow()
+    attachment = MagicMock()
+    attachment.url = 'https://cdn.discordapp.com/image.png'
+    msg.attachments = [attachment]
 
     async def history(*args, **kwargs):
         yield msg
@@ -48,6 +51,13 @@ async def run(suite, ctx) -> List[str]:
 
     if saved.get('data', {}).get('id') == thread.id:
         logs.append('✅ sheet saved')
+        if (
+            saved["data"]["messages"]
+            and saved["data"]["messages"][0].get("attachments") == [attachment.url]
+        ):
+            logs.append('✅ attachment saved')
+        else:
+            logs.append('❌ attachment not saved')
     else:
         logs.append('❌ sheet not saved')
 


### PR DESCRIPTION
## Summary
- include message attachments when backing up character sheets
- test backing up attachments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718c45095c832f8190ee967dbfad35