### PR TITLE
Fix archiving of long character sheets

### DIFF
--- a/NightCityBot/cogs/character_manager.py
+++ b/NightCityBot/cogs/character_manager.py
@@ -75,13 +75,21 @@ class CharacterManager(commands.Cog):
             content = None
             if messages:
                 first = messages.pop(0)
-                content = first.content or None
+                full_content = first.content or ""
                 files = [await a.to_file() for a in first.attachments]
+                content = full_content[:2000] if full_content else None
+                remainder = full_content[2000:] if len(full_content) > 2000 else None
+            else:
+                remainder = None
 
             created = await destination.create_thread(
                 name=thread.name, content=content, files=files or None
             )
             new_thread = created.thread if hasattr(created, "thread") else created
+
+            if remainder:
+                for i in range(0, len(remainder), 2000):
+                    await new_thread.send(content=remainder[i : i + 2000])
 
             for msg in messages:
                 msg_files = [await a.to_file() for a in msg.attachments]

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -64,6 +64,7 @@ TEST_MODULES = {
     "test_eviction_on_baseline_failure": "Eviction notices sent when baseline deduction fails.",
     "test_negative_cash": "Handles baseline deduction when cash is negative.",
     "test_character_manager": "Moves retired threads and searches sheets.",
+    "test_copy_thread_truncate": "Ensures long thread posts are truncated when archived.",
 }
 
 for name in TEST_MODULES:

--- a/NightCityBot/tests/test_copy_thread_truncate.py
+++ b/NightCityBot/tests/test_copy_thread_truncate.py
@@ -1,0 +1,54 @@
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+import discord
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure long thread posts are truncated when archived."""
+    logs: List[str] = []
+    cog = suite.bot.get_cog('CharacterManager')
+    if not cog:
+        logs.append('❌ CharacterManager cog not loaded')
+        return logs
+
+    dest = MagicMock(spec=discord.ForumChannel)
+    new_thread = MagicMock(spec=discord.Thread)
+    new_thread.send = AsyncMock()
+    dest.create_thread = AsyncMock(return_value=new_thread)
+
+    first = MagicMock()
+    first.content = 'A' * 2100
+    first.attachments = []
+    second = MagicMock()
+    second.content = 'B'
+    second.attachments = []
+
+    async def history(*args, **kwargs):
+        yield first
+        yield second
+
+    thread = MagicMock(spec=discord.Thread)
+    thread.history = history
+    thread.delete = AsyncMock()
+    thread.name = 'Example'
+    thread.id = 123
+
+    ok = await cog._copy_thread(thread, dest)
+
+    if not ok:
+        logs.append('❌ copy failed')
+        return logs
+
+    try:
+        dest.create_thread.assert_awaited()
+        new_thread.send.assert_awaited()
+        content = dest.create_thread.await_args.kwargs.get('content')
+        if content is None:
+            content = dest.create_thread.await_args.args[1]
+        if len(content) <= 2000 and new_thread.send.await_count == 2:
+            logs.append('✅ truncated')
+        else:
+            logs.append('❌ not truncated')
+    except Exception as e:
+        logs.append(f'❌ exception {e}')
+
+    return logs

--- a/NightCityBot/tests/test_pytest_copy_thread_truncate.py
+++ b/NightCityBot/tests/test_pytest_copy_thread_truncate.py
@@ -1,0 +1,42 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import discord
+from NightCityBot.cogs.character_manager import CharacterManager
+from NightCityBot.cogs.test_suite import TestSuite
+from NightCityBot.tests.test_copy_thread_truncate import run as run_truncate
+
+class DummyBot:
+    def __init__(self):
+        self.cogs = {}
+        self.loop = asyncio.new_event_loop()
+    def add_cog(self, cog):
+        self.cogs[cog.__class__.__name__] = cog
+    def get_cog(self, name):
+        return self.cogs.get(name)
+
+class DummyCtx:
+    def __init__(self):
+        self.guild = MagicMock()
+        self.author = MagicMock()
+        self.channel = MagicMock()
+        self.send = AsyncMock()
+        self.message = MagicMock(attachments=[])
+
+
+def setup_suite():
+    bot = DummyBot()
+    bot.add_cog(CharacterManager(bot))
+    ts = TestSuite(bot)
+    bot.add_cog(ts)
+    return ts
+
+
+def run_test(func):
+    suite = setup_suite()
+    ctx = DummyCtx()
+    return asyncio.run(func(suite, ctx))
+
+
+def test_copy_thread_truncate():
+    logs = run_test(run_truncate)
+    assert all("❌" not in l for l in logs), f"Logs: {logs}"


### PR DESCRIPTION
## Summary
- truncate the first post when archiving character sheet threads so that it meets Discord limits
- add a regression test for archiving long posts

## Testing
- `pytest NightCityBot/tests/test_pytest_copy_thread_truncate.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719122f124832fbc2755e09afff83c