### PR TITLE
Fix DM thread detection

### DIFF
--- a/NightCityBot/cogs/dm_handling.py
+++ b/NightCityBot/cogs/dm_handling.py
@@ -109,6 +109,9 @@ class DMHandler(commands.Cog):
     async def handle_thread_message(self, message: discord.Message):
         """Handle messages sent in DM logging threads."""
         await self.load_event.wait()
+        parent_id = getattr(message.channel, "parent_id", None)
+        if parent_id != config.DM_INBOX_CHANNEL_ID:
+            return
         user_id: str | None = None
         for uid, thread_id in self.dm_threads.items():
             if message.channel.id == thread_id:

--- a/NightCityBot/tests/test_dm_thread_autolink.py
+++ b/NightCityBot/tests/test_dm_thread_autolink.py
@@ -12,6 +12,7 @@ async def run(suite, ctx) -> List[str]:
     thread = MagicMock(spec=discord.Thread)
     thread.id = 4242
     thread.name = f"{user.name}-{user.id}"
+    thread.parent_id = config.DM_INBOX_CHANNEL_ID
     thread.send = AsyncMock()
     message = MagicMock()
     message.channel = thread

--- a/NightCityBot/tests/test_dm_unknown_user.py
+++ b/NightCityBot/tests/test_dm_unknown_user.py
@@ -11,6 +11,7 @@ async def run(suite, ctx) -> List[str]:
     thread = MagicMock(spec=discord.Thread)
     thread.id = 9999
     thread.name = f"{user.name}-{user.id}"
+    thread.parent_id = config.DM_INBOX_CHANNEL_ID
     message = MagicMock()
     message.channel = thread
     message.content = "Hello"


### PR DESCRIPTION
## Summary
- ignore thread messages that aren't inside the configured DM forum
- update tests with parent_id so they still target the DM forum

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758bd01cc8832fae494e04c2830028