### PR TITLE
Ensure backup_sheets creates directory

### DIFF
--- a/NightCityBot/cogs/character_manager.py
+++ b/NightCityBot/cogs/character_manager.py
@@ -305,7 +305,9 @@ class CharacterManager(commands.Cog):
             return
 
         backup_dir = Path(config.CHARACTER_BACKUP_DIR)
-        backup_dir.mkdir(exist_ok=True)
+        # Ensure the entire path exists in case CHARACTER_BACKUP_DIR contains
+        # intermediate directories that haven't been created yet.
+        backup_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Backing up character sheets to %s", backup_dir)
 
         saved = 0


### PR DESCRIPTION
## Summary
- ensure `backup_sheets` creates parent directories for backups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e8ab8244832f9b8e8e6d956b34ee