### PR TITLE
Enhance theme with cyberpunk embeds

### DIFF
--- a/NightCityBot/bot.py
+++ b/NightCityBot/bot.py
@@ -150,7 +150,7 @@ app = Flask("")
 
 @app.route("/")
 def home():
-    return "Bot is alive Version 1.2!"
+    return "NCPD Network Link Established // NightCityBot v1.2"
 
 
 def run_flask():

--- a/NightCityBot/cogs/admin.py
+++ b/NightCityBot/cogs/admin.py
@@ -10,6 +10,7 @@ from NightCityBot.utils.permissions import is_fixer
 from NightCityBot.utils import constants
 from NightCityBot.utils import startup_checks
 from NightCityBot.utils.helpers import load_json_file, save_json_file
+from NightCityBot.utils import cyberpunk_embed, CYBERPUNK_COLOR
 
 logger = logging.getLogger(__name__)
 
@@ -92,10 +93,9 @@ class Admin(commands.Cog):
     @commands.command(name="helpme")
     async def helpme(self, ctx):
         """Display help for regular users."""
-        embed = discord.Embed(
+        embed = cyberpunk_embed(
             title="📘 NCRP Bot — Player Help",
             description="Basic commands for RP, rent, and rolling dice. Use `!helpfixer` if you're a Fixer.",
-            color=discord.Color.teal(),
         )
 
         embed.add_field(
@@ -209,10 +209,9 @@ class Admin(commands.Cog):
         ]
 
         embeds = []
-        current = discord.Embed(
+        current = cyberpunk_embed(
             title="🛠️ NCRP Bot — Fixer Help",
             description="Advanced commands for messaging, RP management, and rent.",
-            color=discord.Color.purple(),
         )
         for name, value in fields:
             chunks = [value[i : i + 1024] for i in range(0, len(value), 1024)] or [""]
@@ -221,9 +220,8 @@ class Admin(commands.Cog):
                 if embed_len(current) + len(field_name) + len(chunk) > 5800:
                     current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
                     embeds.append(current)
-                    current = discord.Embed(
+                    current = cyberpunk_embed(
                         title="🛠️ NCRP Bot — Fixer Help (cont.)",
-                        color=discord.Color.purple(),
                     )
                 current.add_field(name=field_name, value=chunk, inline=False)
 
@@ -276,10 +274,9 @@ class Admin(commands.Cog):
         ]
 
         embeds = []
-        current = discord.Embed(
+        current = cyberpunk_embed(
             title="🛠️ NCRP Bot — Admin Help",
             description="Commands for admins only.",
-            color=discord.Color.dark_gold(),
         )
         for name, value in fields:
             chunks = [value[i : i + 1024] for i in range(0, len(value), 1024)] or [""]
@@ -288,9 +285,8 @@ class Admin(commands.Cog):
                 if embed_len(current) + len(field_name) + len(chunk) > 5800:
                     current.set_footer(text="Fixer tools by MedusaCascade | v1.2")
                     embeds.append(current)
-                    current = discord.Embed(
+                    current = cyberpunk_embed(
                         title="🛠️ NCRP Bot — Admin Help (cont.)",
-                        color=discord.Color.dark_gold(),
                     )
                 current.add_field(name=field_name, value=chunk, inline=False)
 
@@ -412,7 +408,7 @@ class Admin(commands.Cog):
         audit_channel = self.bot.get_channel(config.AUDIT_LOG_CHANNEL_ID)
 
         if isinstance(audit_channel, discord.TextChannel):
-            embed = discord.Embed(title="📝 Audit Log", color=discord.Color.blue())
+            embed = cyberpunk_embed(title="📝 Audit Log")
             embed.add_field(name="User", value=f"{user} ({user.id})", inline=False)
             chunks = [action_desc[i : i + 1024] for i in range(0, len(action_desc), 1024)] or [""]
             embed.add_field(name="Action", value=chunks[0], inline=False)

--- a/NightCityBot/utils/__init__.py
+++ b/NightCityBot/utils/__init__.py
@@ -1,0 +1,1 @@
+from .style import cyberpunk_embed, CYBERPUNK_COLOR

--- a/NightCityBot/utils/style.py
+++ b/NightCityBot/utils/style.py
@@ -1,0 +1,11 @@
+import discord
+
+CYBERPUNK_COLOR = discord.Color.from_rgb(255, 0, 255)
+
+
+def cyberpunk_embed(title: str | None = None,
+                    description: str | None = None,
+                    *,
+                    color: discord.Color = CYBERPUNK_COLOR) -> discord.Embed:
+    """Return an embed using the default cyberpunk style."""
+    return discord.Embed(title=title, description=description, color=color)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NightCityBot
 
-NightCityBot is a Discord bot built with `discord.py` that provides roleplay utilities, economy management and automated moderation tools for a Cyberpunk themed server.  The bot is organised using *cogs* – modular components that group related commands and background tasks.
+NightCityBot is a Discord bot built with `discord.py` that provides roleplay utilities, economy management and automated moderation tools for a Cyberpunk themed server.  The bot is organised using *cogs* – modular components that group related commands and background tasks. By default it uses a neon magenta embed color for a Cyberpunk 2077 inspired feel.
 
 This document gives an overview of the major modules and how they work.
 


### PR DESCRIPTION
## Summary
- add `cyberpunk_embed` helper and default color
- apply cyberpunk theme to help and audit messages
- tweak the keep-alive route message
- document neon styling in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879b74dae50832f859983bb5379065d