### PR TITLE
Fix cyberware week tracking

### DIFF
--- a/NightCityBot/tests/test_checkup_command.py
+++ b/NightCityBot/tests/test_checkup_command.py
@@ -28,7 +28,9 @@ async def run(suite, ctx) -> List[str]:
         await cyber.checkup.callback(cyber, ctx, member)
     suite.assert_send(logs, member.remove_roles, "remove_roles")
     suite.assert_send(logs, log_channel.send, "log_channel.send")
-    if cyber.data.get(str(member.id), 0) == 0:
+    from datetime import date
+    expected = date.today().isoformat()
+    if cyber.data.get(str(member.id)) == expected:
         logs.append("✅ checkup streak reset")
     else:
         logs.append("❌ checkup streak not reset")

--- a/NightCityBot/tests/test_list_deficits.py
+++ b/NightCityBot/tests/test_list_deficits.py
@@ -20,7 +20,8 @@ async def run(suite, ctx) -> List[str]:
     medium = discord.Object(id=config.CYBER_MEDIUM_ROLE_ID)
     checkup = discord.Object(id=config.CYBER_CHECKUP_ROLE_ID)
     user.roles = [role_h, role_b, medium, checkup]
-    cyber.data[str(user.id)] = 0
+    from datetime import date, timedelta
+    cyber.data[str(user.id)] = (date.today() - timedelta(days=7)).isoformat()
     ctx.guild.members = [user]
     ctx.send = AsyncMock()
 

--- a/NightCityBot/tests/test_simulate_rent_cyberware.py
+++ b/NightCityBot/tests/test_simulate_rent_cyberware.py
@@ -14,7 +14,8 @@ async def run(suite, ctx) -> List[str]:
     checkup = discord.Object(id=config.CYBER_CHECKUP_ROLE_ID)
     approved = discord.Object(id=config.APPROVED_ROLE_ID)
     user.roles = [medium, checkup, approved]
-    cyber.data[str(user.id)] = 0
+    from datetime import date, timedelta
+    cyber.data[str(user.id)] = (date.today() - timedelta(days=7)).isoformat()
     ctx.send = AsyncMock()
     with (
         patch.object(economy.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 1000, "bank": 0})),


### PR DESCRIPTION
## Summary
- store ISO timestamp of last ripperdoc checkup per user
- calculate weeks since last checkup during weekly processing
- update checkup command to save timestamp
- adjust tests for the new data format

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de6bc335c832fb2b802ef00e810fe