### PR TITLE
Fix cyberware week tracking

### DIFF
--- a/NightCityBot/cogs/cyberware.py
+++ b/NightCityBot/cogs/cyberware.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands, tasks
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
 from typing import Dict, Optional, List
 from pathlib import Path
@@ -30,13 +30,34 @@ class CyberwareManager(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.unbelievaboat = UnbelievaBoatAPI(config.UNBELIEVABOAT_API_TOKEN)
-        self.data: Dict[str, int] = {}
+        self.data: Dict[str, Dict[str, Optional[str] | int]] = {}
+        self.last_run: Optional[datetime] = None
         self.bot.loop.create_task(self.load_data())
         self.weekly_check.start()
 
     async def load_data(self):
         path = Path(config.CYBERWARE_LOG_FILE)
-        self.data = await load_json_file(path, default={})
+        raw = await load_json_file(path, default={})
+        if isinstance(raw, dict):
+            ts = raw.get("_last_run")
+            if ts:
+                try:
+                    self.last_run = datetime.fromisoformat(ts)
+                except Exception:
+                    self.last_run = None
+            self.data = {}
+            for k, v in raw.items():
+                if k == "_last_run":
+                    continue
+                if isinstance(v, dict):
+                    self.data[k] = {
+                        "weeks": int(v.get("weeks", 0)),
+                        "last": v.get("last"),
+                    }
+                else:
+                    self.data[k] = {"weeks": int(v), "last": None}
+        else:
+            self.data = {}
 
     def cog_unload(self):
         self.weekly_check.cancel()
@@ -46,6 +67,14 @@ class CyberwareManager(commands.Cog):
         base = BASE_FACTOR[level]
         cost = int(base * (2 ** (weeks - 1)))
         return min(cost, MAX_COST[level])
+
+    def _week_increment(self) -> int:
+        """Return how many weeks have passed since the last full run."""
+        if self.last_run:
+            delta = datetime.utcnow() - self.last_run
+            inc = delta.days // 7
+            return inc if inc >= 1 else 1
+        return 1
 
     @tasks.loop(time=time(hour=0, tzinfo=ZoneInfo(getattr(config, "TIMEZONE", "UTC"))))
     async def weekly_check(self):
@@ -119,6 +148,7 @@ class CyberwareManager(commands.Cog):
 
         results = {"checkup": [], "paid": [], "unpaid": []}
 
+        week_inc = self._week_increment()
         members = [target_member] if target_member else guild.members
         for member in members:
             if not any(r.id == config.APPROVED_ROLE_ID for r in member.roles):
@@ -134,7 +164,18 @@ class CyberwareManager(commands.Cog):
                 role_level = "medium"
 
             user_id = str(member.id)
-            weeks = self.data.get(user_id, 0)
+            entry = self.data.get(user_id, {"weeks": 0, "last": None})
+            weeks = entry.get("weeks", 0)
+            last_ts = entry.get("last")
+            member_inc = week_inc
+            if last_ts:
+                try:
+                    delta = datetime.utcnow() - datetime.fromisoformat(last_ts)
+                    inc = delta.days // 7
+                    if inc > 0:
+                        member_inc = max(member_inc, inc)
+                except Exception:
+                    pass
 
             has_checkup = checkup_role in member.roles if checkup_role else False
 
@@ -163,11 +204,11 @@ class CyberwareManager(commands.Cog):
                     )
                 results["checkup"].append(member.id)
                 if not dry_run:
-                    self.data[user_id] = 0
+                    self.data[user_id] = {"weeks": 0, "last": None}
                 continue
 
             # User kept the checkup role for another week → charge them
-            weeks += 1
+            weeks += member_inc
             cost = self.calculate_cost(role_level, weeks)
             if log is not None:
                 log.append(f"Processing <@{member.id}> — week {weeks} cost ${cost}")
@@ -238,13 +279,21 @@ class CyberwareManager(commands.Cog):
                             results["unpaid"].append(member.id)
 
             if not dry_run:
-                self.data[user_id] = weeks
+                self.data[user_id] = {
+                    "weeks": weeks,
+                    "last": datetime.utcnow().isoformat(),
+                }
                 if log is not None:
                     log.append(f"Streak is now {weeks} week(s) for <@{member.id}>")
             elif log is not None:
                 log.append(f"Streak would become {weeks} week(s) for <@{member.id}>")
         if not dry_run:
-            await save_json_file(Path(config.CYBERWARE_LOG_FILE), self.data)
+            if target_member is None:
+                self.last_run = datetime.utcnow()
+            save_payload = {**self.data}
+            if self.last_run:
+                save_payload["_last_run"] = self.last_run.isoformat()
+            await save_json_file(Path(config.CYBERWARE_LOG_FILE), save_payload)
             if log is not None:
                 log.append("✅ Data saved.")
         elif log is not None:
@@ -355,14 +404,18 @@ class CyberwareManager(commands.Cog):
                 f"Ripperdoc {ctx.author.display_name} did a checkup on {member.display_name}"
             )
 
-        self.data[str(member.id)] = 0
-        await save_json_file(Path(config.CYBERWARE_LOG_FILE), self.data)
+        self.data[str(member.id)] = {"weeks": 0, "last": None}
+        payload = {**self.data}
+        if self.last_run:
+            payload["_last_run"] = self.last_run.isoformat()
+        await save_json_file(Path(config.CYBERWARE_LOG_FILE), payload)
 
     @commands.command(aliases=["weekswithoutcheckup", "wwocup", "wwc"])
     @commands.check_any(is_ripperdoc(), is_fixer())
     async def weeks_without_checkup(self, ctx, member: discord.Member):
         """Show how many weeks a member has gone without a checkup."""
-        weeks = self.data.get(str(member.id), 0)
+        entry = self.data.get(str(member.id))
+        weeks = entry.get("weeks", 0) if isinstance(entry, dict) else int(entry or 0)
         await ctx.send(f"{member.display_name} has gone {weeks} week(s) without a checkup.")
 
     @commands.command(name="give_checkup_role", aliases=["givecheckuprole", "givecheckups", "cuall", "checkupall"])

--- a/NightCityBot/tests/__init__.py
+++ b/NightCityBot/tests/__init__.py
@@ -37,6 +37,7 @@ TEST_MODULES = {
     "test_dm_unknown_user": "Handles missing user ID when relaying from DM thread.",
     "test_start_rp_multi": "Starts RP with two users and ends it.",
     "test_cyberware_weekly": "Simulates the weekly cyberware task.",
+    "test_cyberware_streak": "Ensures missed weeks increment streak correctly.",
     "test_loa_fixer_other": "Fixer starts and ends LOA for another user.",
     "test_loa_id_check": "Handles LOA with distinct role instances sharing an ID.",
     "test_roll_as_user": "Rolls on behalf of another user.",

--- a/NightCityBot/tests/test_cyberware_streak.py
+++ b/NightCityBot/tests/test_cyberware_streak.py
@@ -1,0 +1,45 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timedelta
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure missed weeks increment the cyberware streak."""
+    logs: List[str] = []
+    manager = suite.bot.get_cog('CyberwareManager')
+    if not manager:
+        logs.append("❌ CyberwareManager cog not loaded")
+        return logs
+    guild = MagicMock()
+    check = discord.Object(id=config.CYBER_CHECKUP_ROLE_ID)
+    medium = discord.Object(id=config.CYBER_MEDIUM_ROLE_ID)
+    guild.get_role.side_effect = lambda rid: {config.CYBER_CHECKUP_ROLE_ID: check,
+                                              config.CYBER_MEDIUM_ROLE_ID: medium}.get(rid)
+    member = MagicMock(spec=discord.Member)
+    member.id = 1
+    member.roles = [medium, check]
+    member.add_roles = AsyncMock()
+    guild.members = [member]
+    log_channel = MagicMock()
+    log_channel.send = AsyncMock()
+    guild.get_channel.return_value = log_channel
+    manager.data[str(member.id)] = {
+        "weeks": 1,
+        "last": (datetime.utcnow() - timedelta(days=14)).isoformat(),
+    }
+    manager.last_run = datetime.utcnow() - timedelta(days=14)
+    with (
+        patch.object(suite.bot, "get_guild", return_value=guild),
+        patch.object(manager.unbelievaboat, "get_balance", new=AsyncMock(return_value={"cash": 5000, "bank": 0})),
+        patch.object(manager.unbelievaboat, "update_balance", new=AsyncMock(return_value=True)),
+        patch("NightCityBot.cogs.cyberware.save_json_file", new=AsyncMock()),
+    ):
+        await manager.process_week()
+    entry = manager.data.get(str(member.id))
+    result = entry.get("weeks") if isinstance(entry, dict) else None
+    if result == 3:
+        logs.append("✅ streak advanced by missed weeks")
+    else:
+        logs.append(f"❌ streak incorrect: {result}")
+    return logs

--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ Commands:
 * `!collect_cyberware @user [-v]` – manually charge a member for their meds unless they already paid or did a checkup this week. Without `-v` only the last few log lines are shown.
 * `!paycyberware [-v]` – pay your own cyberware meds manually. Mirrors `!collect_cyberware` but only affects you.
 
-All data is stored in `cyberware_log.json`. Weekly results are appended to `cyberware_weekly.json`.
+All data is stored in `cyberware_log.json`. The file now keeps each user's
+streak together with a ``last`` timestamp indicating when that player was last
+processed. The file also stores a `_last_run` timestamp for the most recent
+weekly task. Weekly results are appended to `cyberware_weekly.json`.
 
 ### RPManager
 *File: `NightCityBot/cogs/rp_manager.py`*
@@ -213,7 +216,8 @@ Several JSON files store runtime data:
 * `thread_map.json` – mapping of user IDs to DM log thread IDs.
 * `business_open_log.json` – timestamps of each user's `!open_shop` usage.
 * `attendance_log.json` – records weekly attendance.
-* `cyberware_log.json` – weeks since last check‑up for each user.
+* `cyberware_log.json` – for each user stores the streak and the last time they
+  were processed, plus the last run timestamp for the weekly task.
 * `system_status.json` – persisted enable/disable flags for subsystems.
 
 These files are loaded on startup via `utils.helpers.load_json_file`.


### PR DESCRIPTION
## Summary
- store per-user streak data with last processed timestamp
- update cyberware manager logic to compute increments from each player's last timestamp
- clarify cyberware log structure in README
- adjust streak regression test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687de6bc335c832fb2b802ef00e810fe