### PR TITLE
Skip ripperdocs from cyberware checkups

### DIFF
--- a/NightCityBot/cogs/cyberware.py
+++ b/NightCityBot/cogs/cyberware.py
@@ -144,6 +144,7 @@ class CyberwareManager(commands.Cog):
         high_role = guild.get_role(config.CYBER_HIGH_ROLE_ID)
         extreme_role = guild.get_role(config.CYBER_EXTREME_ROLE_ID)
         loa_role = guild.get_role(config.LOA_ROLE_ID)
+        ripper_role = guild.get_role(config.RIPPERDOC_ROLE_ID)
         log_channel = guild.get_channel(config.RIPPERDOC_LOG_CHANNEL_ID)
 
         results = {"checkup": [], "paid": [], "unpaid": []}
@@ -155,6 +156,8 @@ class CyberwareManager(commands.Cog):
             if not any(r.id == config.APPROVED_ROLE_ID for r in member.roles):
                 continue
             if loa_role and loa_role in member.roles:
+                continue
+            if ripper_role and ripper_role in member.roles:
                 continue
             role_level = None
             if extreme_role and extreme_role in member.roles:
@@ -432,6 +435,7 @@ class CyberwareManager(commands.Cog):
         high_role = guild.get_role(config.CYBER_HIGH_ROLE_ID)
         extreme_role = guild.get_role(config.CYBER_EXTREME_ROLE_ID)
         loa_role = guild.get_role(config.LOA_ROLE_ID)
+        ripper_role = guild.get_role(config.RIPPERDOC_ROLE_ID)
         if checkup_role is None:
             await ctx.send("⚠️ Checkup role is not configured.")
             return
@@ -440,6 +444,8 @@ class CyberwareManager(commands.Cog):
         count = 0
         for m in members:
             if loa_role and loa_role in m.roles:
+                continue
+            if ripper_role and ripper_role in m.roles:
                 continue
             has_cyber = any(
                 r for r in (medium_role, high_role, extreme_role) if r and r in m.roles

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The cog stores logs in JSON files such as `business_open_log.json` and `attendan
 
 Implements weekly check‑up reminders and medication costs for players with cyberware. A background task runs every Saturday:
 
-1. Gives the `CYBER_CHECKUP_ROLE_ID` role each week.
+1. Gives the `CYBER_CHECKUP_ROLE_ID` role each week (Ripperdocs are skipped).
 2. If the role is kept the following week, deducts a cost based on the cyberware level (medium/high/extreme).
 
 Commands:


### PR DESCRIPTION
## Summary
- skip members with the Ripperdoc role when processing weekly cyberware tasks
- ignore Ripperdocs when manually assigning the checkup role
- document this behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_b_687ec315bd6883229a61f8d1380a1a24