### PR TITLE
Add member parameter to due command

### DIFF
--- a/NightCityBot/cogs/economy.py
+++ b/NightCityBot/cogs/economy.py
@@ -392,20 +392,28 @@ class Economy(commands.Cog):
         return total, details
 
     @commands.command(name="due")
-    async def due(self, ctx):
-        """Show estimated amount you will owe on the 1st of the month.
+    async def due(self, ctx, member: discord.Member | None = None) -> None:
+        """Show estimated amount owed on the 1st of the month.
 
-        Includes upcoming cyberware medication costs if applicable.
+        Optionally provide ``member`` to check someone else's upcoming costs.
         """
+        target = member or ctx.author
         logger.debug(
-            "due command invoked by %s (%s) in %s (%s)",
+            "due command invoked for %s (%s) by %s (%s) in %s (%s)",
+            target,
+            target.id,
             ctx.author,
             ctx.author.id,
             getattr(ctx.channel, "name", ctx.channel.id),
             ctx.channel.id,
         )
-        total, details = self.calculate_due(ctx.author)
-        lines = [f"💸 **Estimated Due:** ${total}"] + [f"• {d}" for d in details]
+        total, details = self.calculate_due(target)
+        header = (
+            f"💸 **Estimated Due for {target.display_name}:** ${total}"
+            if member
+            else f"💸 **Estimated Due:** ${total}"
+        )
+        lines = [header] + [f"• {d}" for d in details]
         await ctx.send("\n".join(lines))
 
     @commands.command(name="last_payment")

--- a/NightCityBot/tests/test_due_other_user.py
+++ b/NightCityBot/tests/test_due_other_user.py
@@ -1,0 +1,30 @@
+from typing import List
+import discord
+from unittest.mock import AsyncMock, patch
+import config
+
+async def run(suite, ctx) -> List[str]:
+    """Ensure due can target another member."""
+    logs: List[str] = []
+    economy = suite.bot.get_cog('Economy')
+    if not economy:
+        logs.append('❌ Economy cog not loaded')
+        return logs
+    user = await suite.get_test_user(ctx)
+    ctx.send = AsyncMock()
+
+    captured = {}
+    def fake_calculate(member):
+        captured['member'] = member
+        return 123, ['item']
+
+    with patch.object(economy, 'calculate_due', side_effect=fake_calculate):
+        await economy.due.callback(economy, ctx, user)
+
+    suite.assert_send(logs, ctx.send, 'ctx.send')
+    if captured.get('member') is user:
+        logs.append('✅ member argument respected')
+    else:
+        logs.append('❌ member argument ignored')
+    return logs
+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Main commands:
 * `!open_shop` – used by business owners on Sundays. Logs a shop opening and immediately awards passive income based on the business tier. Each player can record up to four openings per month.
 * `!attend` – every verified player can run this on Sundays to receive a weekly $250 attendance reward. The command refuses to run more than once per week.
 * `!event_start` – fixers can activate this in the attendance channel to temporarily allow `!attend` and `!open_shop` for four hours outside of Sunday.
-* `!due` – displays a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st.
+* `!due [@user]` – show a full breakdown of the baseline fee, housing and business rent, Trauma Team subscription and upcoming cyberware medication costs that will be charged on the 1st. When a user is supplied the estimate is for that member.
 * `!last_payment` – show the details of your last automated payment.
 * `!collect_rent [@user] [-v] [-force]` – run the monthly rent cycle. Supply a user mention to limit the collection to that member. Use `-force` to ignore the 30 day cooldown. With `-v`, each step is announced as it happens and balance backup progress for each member is shown so you can track the cycle live.
 * `!paydue [-v]` – pay your monthly obligations early. Works like `!collect_rent` but only for yourself. Use `-v` for a detailed summary.


### PR DESCRIPTION
## Summary
- extend `!due` to accept an optional member argument
- document this new usage in the README
- add unit test exercising due with another user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecf1452c8832fbc7148a130e4b2ac